### PR TITLE
Improved cursor replacement and clicker radius fix

### DIFF
--- a/ClickerClass.cs
+++ b/ClickerClass.cs
@@ -19,8 +19,7 @@ namespace ClickerClass
 		{
 			mod = this;
 			AutoClickKey = RegisterHotKey("Clicker Accessory", "G");
-			ShaderManager.Load();
-			
+
 			if (!Main.dedServ)
 			{
 				LoadClient();
@@ -29,6 +28,7 @@ namespace ClickerClass
 
 		private void LoadClient()
 		{
+			ShaderManager.Load();
 			ClickerInterfaceResources.Load();
 		}
 		
@@ -43,18 +43,19 @@ namespace ClickerClass
 		public override void ModifyInterfaceLayers(List<GameInterfaceLayer> layers)
 		{
 			ClickerInterfaceResources.AddDrawLayers(layers);
-			
+
 			Player player = Main.LocalPlayer;
 			for (int i = 0; i < layers.Count; i++)
             {
                 //Remove Mouse Cursor
-				if (player.HeldItem.modItem is ClickerItem clickerItem && clickerItem.isClicker && player.HeldItem.damage > 0)
+				if (ClickerCursor.CanDrawCursor(player.HeldItem))
 				{
 					if (Main.cursorOverride == -1 && ClickerConfigClient.Instance.ShowCustomCursors)
 					{
-						if (layers[i].Name.Contains("Cursor"))
+						if (layers[i].Name.Equals("Vanilla: Cursor"))
 						{
 							layers.RemoveAt(i);
+							break;
 						}
 					}
 				}

--- a/ClickerPlayer.cs
+++ b/ClickerPlayer.cs
@@ -657,11 +657,6 @@ namespace ClickerClass
 			
 			if (Main.gameMenu) return;
 
-			if (drawInfo.shadow != 0f)
-			{
-				return;
-			}
-
 			ClickerPlayer modPlayer = drawPlayer.GetModPlayer<ClickerPlayer>();
 
 			if (!drawPlayer.dead)

--- a/UI/ClickerCursor.cs
+++ b/UI/ClickerCursor.cs
@@ -58,17 +58,11 @@ namespace ClickerClass.UI
 			Rectangle frame2 = texture2.Frame(1, 1);
 			Vector2 origin2 = frame2.Size() / 2;
 
-			// player.gfxOffY changes depending on if a player is moving on top of half or slanted blocks
-			// Adding player.gfxOffY to the position calculation prevents position glitching
-			Vector2 position = new Vector2(Main.MouseWorld.X + 8, Main.MouseWorld.Y + 11 + player.gfxOffY);
-			Vector2 position2 = new Vector2(Main.MouseWorld.X + 8, Main.MouseWorld.Y + 11 + player.gfxOffY);
+			Vector2 position = new Vector2(Main.mouseX + 8, Main.mouseY + 11);
+			Vector2 position2 = new Vector2(Main.mouseX + 8, Main.mouseY + 11);
 			Color color = Color.White;
 
-			// Calculates UI position depending on UI scale
-			position = Vector2.Transform(position - Main.screenPosition, Main.GameViewMatrix.ZoomMatrix) / Main.UIScale;
-			position2 = Vector2.Transform(position2 - Main.screenPosition, Main.GameViewMatrix.ZoomMatrix) / Main.UIScale;
-
-			// Draw the darker background of the bar
+			// Draw cursor border
 			Main.spriteBatch.Draw(texture, position, frame, Main.mouseBorderColorSlider.GetColor(), 0f, origin, 1f + _clickerScale, SpriteEffects.FlipHorizontally, 0f);
 			Main.spriteBatch.Draw(texture2, position2, frame2, color, 0f, origin2, 1f + _clickerScale, SpriteEffects.FlipHorizontally, 0f);
 			

--- a/UI/ClickerCursor.cs
+++ b/UI/ClickerCursor.cs
@@ -1,11 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.UI;
 using ClickerClass.Items;
-using ClickerClass.Utilities;
 
 namespace ClickerClass.UI
 {
@@ -17,6 +15,9 @@ namespace ClickerClass.UI
 		private float _clickerAlpha = 0f;
 		private static bool _lastMouseInterface = false;
 
+		/// <summary>
+		/// Helper method that determines when the cursor can be drawn/replaced
+		/// </summary>
 		public static bool CanDrawCursor(Item item)
 		{
 			return !_lastMouseInterface && item.modItem is ClickerItem clickerItem && clickerItem.isClicker && item.damage > 0;
@@ -28,7 +29,7 @@ namespace ClickerClass.UI
 			// For some reason cursorAlpha is "flipped", revert it here via some maths (0.8 is the value it fluctuates around)
 			float flipped = 2 * 0.8f - Main.cursorAlpha;
 			_clickerAlpha = flipped * 0.3f + 0.7f;
-			// To safely cache when the cursor is inside an interface (directly accessing it adding the cursor will not work because the vanilla logic hasn't reached that stage yet)
+			// To safely cache when the cursor is inside an interface (directly accessing it when adding the cursor will not work because the vanilla logic hasn't reached that stage yet)
 			_lastMouseInterface = Main.LocalPlayer.mouseInterface;
 		}
 		

--- a/UI/ClickerCursor.cs
+++ b/UI/ClickerCursor.cs
@@ -14,26 +14,27 @@ namespace ClickerClass.UI
 		public ClickerCursor() : base("ClickerClass: Clicker", InterfaceScaleType.UI) { }
 
 		private float _clickerScale = 0f;
-		private bool _clickerScaleShift = false;
-		
+		private float _clickerAlpha = 0f;
+		private static bool _lastMouseInterface = false;
+
+		public static bool CanDrawCursor(Item item)
+		{
+			return !_lastMouseInterface && item.modItem is ClickerItem clickerItem && clickerItem.isClicker && item.damage > 0;
+		}
+
 		public override void Update(GameTime gameTime)
 		{
-			_clickerScale += !_clickerScaleShift ? 0.005f : -0.005f;
-
-			if (_clickerScale > 0.09f)
-			{
-				_clickerScaleShift = true;
-			}
-			else if (_clickerScale < -0.09f)
-			{
-				_clickerScaleShift = false;
-			}
+			_clickerScale = Main.cursorScale;
+			// For some reason cursorAlpha is "flipped", revert it here via some maths (0.8 is the value it fluctuates around)
+			float flipped = 2 * 0.8f - Main.cursorAlpha;
+			_clickerAlpha = flipped * 0.3f + 0.7f;
+			// To safely cache when the cursor is inside an interface (directly accessing it adding the cursor will not work because the vanilla logic hasn't reached that stage yet)
+			_lastMouseInterface = Main.LocalPlayer.mouseInterface;
 		}
 		
 		protected override bool DrawSelf()
 		{
 			Player player = Main.LocalPlayer;
-			ClickerPlayer clickerPlayer = player.GetClickerPlayer();
 
 			// Don't draw if the player is dead or a ghost
 			if (player.dead || player.ghost || !ClickerConfigClient.Instance.ShowCustomCursors)
@@ -41,30 +42,35 @@ namespace ClickerClass.UI
 				return true;
 			}
 
-			Texture2D texture = ClickerClass.mod.GetTexture("UI/CursorOutline");
-			Texture2D texture2 = ClickerClass.mod.GetTexture("UI/CursorOutline");
-			if (player.HeldItem.modItem is ClickerItem clickerItem && clickerItem.isClicker && player.HeldItem.damage > 0)
+			Texture2D borderTexture = ClickerClass.mod.GetTexture("UI/CursorOutline");
+			Texture2D texture;
+			Item item = player.HeldItem;
+			if (CanDrawCursor(item))
 			{
-				texture2 = Main.itemTexture[player.HeldItem.type];
+				texture = Main.itemTexture[item.type];
 			}
 			else
 			{
 				return true;
 			}
 			
+			Rectangle borderFrame = borderTexture.Frame(1, 1);
+			Vector2 borderOrigin = borderFrame.Size() / 2;
+			
 			Rectangle frame = texture.Frame(1, 1);
 			Vector2 origin = frame.Size() / 2;
-			
-			Rectangle frame2 = texture2.Frame(1, 1);
-			Vector2 origin2 = frame2.Size() / 2;
 
-			Vector2 position = new Vector2(Main.mouseX + 8, Main.mouseY + 11);
-			Vector2 position2 = new Vector2(Main.mouseX + 8, Main.mouseY + 11);
+			Vector2 borderPosition = Main.MouseScreen;
+			// Actual cursor is not drawn in the top left of the border but a bit offset, have to add/substract origins here
+			Vector2 position = Main.MouseScreen - origin + borderOrigin;
+
 			Color color = Color.White;
+			color.A = (byte)(_clickerAlpha * 255);
 
 			// Draw cursor border
-			Main.spriteBatch.Draw(texture, position, frame, Main.mouseBorderColorSlider.GetColor(), 0f, origin, 1f + _clickerScale, SpriteEffects.FlipHorizontally, 0f);
-			Main.spriteBatch.Draw(texture2, position2, frame2, color, 0f, origin2, 1f + _clickerScale, SpriteEffects.FlipHorizontally, 0f);
+			Main.spriteBatch.Draw(borderTexture, borderPosition, borderFrame, Main.mouseBorderColorSlider.GetColor(), 0f, Vector2.Zero, _clickerScale, SpriteEffects.FlipHorizontally, 0f);
+			// Actual cursor
+			Main.spriteBatch.Draw(texture, position, frame, color, 0f, Vector2.Zero, _clickerScale, SpriteEffects.FlipHorizontally, 0f);
 			
 			return true;
 		}


### PR DESCRIPTION
This PR fixes a previously introduced bug with the new clicker radius where it won't appear when an armor shadow is active.

It also improves the newly added cursor replacement code by mimicking cursor scale/alpha, and also prevents replacing it in UIs so that cursor overrides (such as trash/favorite cursor) work properly