### PR TITLE
Fix Mice Clicker non-click damage

### DIFF
--- a/Items/MiceClicker.cs
+++ b/Items/MiceClicker.cs
@@ -16,6 +16,7 @@ namespace ClickerClass.Items
 		public override void SetDefaults()
 		{
 			isClicker = true;
+			isClickerWeapon = true;
 			radiusBoost = 6f;
 			clickerColorItem = new Color(150, 150, 225, 0);
 			clickerDustColor = mod.DustType("MiceDust");


### PR DESCRIPTION
Fixed Mice Clicker missing `isClickerWeapon = true`, causing it to not deal click damage or be affected by clicker stat changes.