### PR TITLE
Cleanup for compile-time safety and a bugfix

### DIFF
--- a/ClickerPlayer.cs
+++ b/ClickerPlayer.cs
@@ -1,6 +1,7 @@
 using ClickerClass.Buffs;
 using ClickerClass.Items;
 using ClickerClass.Items.Armors;
+using ClickerClass.Items.Tools;
 using ClickerClass.NPCs;
 using ClickerClass.Projectiles;
 using ClickerClass.Utilities;
@@ -524,11 +525,11 @@ namespace ClickerClass
 
 					if (accCookie2 && Main.rand.NextFloat() <= 0.1f)
 					{
-						Projectile.NewProjectile((float)(xOffset), (float)(yOffset), 0f, 0f, mod.ProjectileType("CookiePro"), 0, 0f, player.whoAmI, 1f);
+						Projectile.NewProjectile((float)(xOffset), (float)(yOffset), 0f, 0f, ModContent.ProjectileType<CookiePro>(), 0, 0f, player.whoAmI, 1f);
 					}
 					else
 					{
-						Projectile.NewProjectile((float)(xOffset), (float)(yOffset), 0f, 0f, mod.ProjectileType("CookiePro"), 0, 0f, player.whoAmI);
+						Projectile.NewProjectile((float)(xOffset), (float)(yOffset), 0f, 0f, ModContent.ProjectileType<CookiePro>(), 0, 0f, player.whoAmI);
 					}
 
 					accCookieTimer = 0;
@@ -548,7 +549,7 @@ namespace ClickerClass
 								if (cookieProjectile.ai[0] == 1f)
 								{
 									Main.PlaySound(2, (int)player.position.X, (int)player.position.Y, 4);
-									player.AddBuff(mod.BuffType("CookieBuff"), 600);
+									player.AddBuff(ModContent.BuffType<CookieBuff>(), 600);
 									player.HealLife(10);
 									for (int k = 0; k < 10; k++)
 									{
@@ -559,7 +560,7 @@ namespace ClickerClass
 								else
 								{
 									Main.PlaySound(2, (int)player.position.X, (int)player.position.Y, 2);
-									player.AddBuff(mod.BuffType("CookieBuff"), 300);
+									player.AddBuff(ModContent.BuffType<CookieBuff>(), 300);
 									for (int k = 0; k < 10; k++)
 									{
 										Dust dust = Dust.NewDustDirect(cookieProjectile.Center, 20, 20, 0, Main.rand.NextFloat(-4f, 4f), Main.rand.NextFloat(-4f, 4f), 75, default, 1.5f);
@@ -877,7 +878,7 @@ namespace ClickerClass
 			Mod mod = ModLoader.GetMod("ClickerClass");
 
 			//Fragment Pickaxe
-			if (drawPlayer.HeldItem.type == mod.ItemType("MicePickaxe"))
+			if (drawPlayer.HeldItem.type == ModContent.ItemType<MicePickaxe>())
 			{
 				Texture2D weaponGlow = mod.GetTexture("Glowmasks/MicePickaxe_Glow");
 				Vector2 position = new Vector2((int)(drawInfo.itemLocation.X - Main.screenPosition.X), (int)(drawInfo.itemLocation.Y - Main.screenPosition.Y));
@@ -887,7 +888,7 @@ namespace ClickerClass
 			}
 
 			//Fragment Hamaxe
-			if (drawPlayer.HeldItem.type == mod.ItemType("MiceHamaxe"))
+			if (drawPlayer.HeldItem.type == ModContent.ItemType<MiceHamaxe>())
 			{
 				Texture2D weaponGlow = mod.GetTexture("Glowmasks/MiceHamaxe_Glow");
 				Vector2 position = new Vector2((int)(drawInfo.itemLocation.X - Main.screenPosition.X), (int)(drawInfo.itemLocation.Y - Main.screenPosition.Y));

--- a/ClickerRecipes.cs
+++ b/ClickerRecipes.cs
@@ -1,4 +1,5 @@
-﻿using Terraria;
+﻿using ClickerClass.Items.Accessories;
+using Terraria;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
@@ -15,7 +16,7 @@ namespace ClickerClass
 		public static void AddRecipes()
 		{
 			ModRecipe recipe = GetNewRecipe();
-			recipe.AddIngredient(null, "ClickerEmblem", 1);
+			recipe.AddIngredient(ModContent.ItemType<ClickerEmblem>(), 1);
 			recipe.AddIngredient(ItemID.SoulofMight, 5);
 			recipe.AddIngredient(ItemID.SoulofSight, 5);
 			recipe.AddIngredient(ItemID.SoulofFright, 5);

--- a/Items/Accessories/AncientClickingGlove.cs
+++ b/Items/Accessories/AncientClickingGlove.cs
@@ -30,7 +30,7 @@ namespace ClickerClass.Items.Accessories
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "ClickingGlove", 1);
+			recipe.AddIngredient(ModContent.ItemType<ClickingGlove>(), 1);
 			recipe.AddIngredient(ItemID.AncientCloth, 8);
 			recipe.AddTile(TileID.MythrilAnvil);
 			recipe.SetResult(this);

--- a/Items/Accessories/ChocolateMilkCookies.cs
+++ b/Items/Accessories/ChocolateMilkCookies.cs
@@ -36,8 +36,8 @@ namespace ClickerClass.Items.Accessories
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "ChocolateChip", 1);
-			recipe.AddIngredient(null, "MilkCookies", 1);
+			recipe.AddIngredient(ModContent.ItemType<ChocolateChip>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<MilkCookies>(), 1);
 			recipe.AddTile(TileID.TinkerersWorkbench);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/Items/Accessories/GamerCrate.cs
+++ b/Items/Accessories/GamerCrate.cs
@@ -45,10 +45,10 @@ namespace ClickerClass.Items.Accessories
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "EnchantedLED", 1);
-			recipe.AddIngredient(null, "Soda", 1);
-			recipe.AddIngredient(null, "MousePad", 1);
-			recipe.AddIngredient(null, "HandCream", 1);
+			recipe.AddIngredient(ModContent.ItemType<EnchantedLED>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<Soda>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<MousePad>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<HandCream>(), 1);
 			recipe.AddTile(TileID.TinkerersWorkbench);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/Items/Accessories/MilkCookies.cs
+++ b/Items/Accessories/MilkCookies.cs
@@ -34,8 +34,8 @@ namespace ClickerClass.Items.Accessories
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "Cookie", 1);
-			recipe.AddIngredient(null, "Milk", 1);
+			recipe.AddIngredient(ModContent.ItemType<Cookie>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<Milk>(), 1);
 			recipe.AddTile(TileID.TinkerersWorkbench);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/Items/Accessories/RegalClickingGlove.cs
+++ b/Items/Accessories/RegalClickingGlove.cs
@@ -30,7 +30,7 @@ namespace ClickerClass.Items.Accessories
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "AncientClickingGlove", 1);
+			recipe.AddIngredient(ModContent.ItemType<AncientClickingGlove>(), 1);
 			recipe.AddIngredient(ItemID.HallowedBar, 8);
 			recipe.AddTile(TileID.MythrilAnvil);
 			recipe.SetResult(this);

--- a/Items/Accessories/TheScroller.cs
+++ b/Items/Accessories/TheScroller.cs
@@ -1,3 +1,4 @@
+using ClickerClass.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.Graphics.Shaders;
@@ -85,7 +86,7 @@ namespace ClickerClass.Items.Accessories
 						Vector2 position = -Vector2.UnitY.RotatedBy(i * MathHelper.TwoPi / numDusts) * new Vector2(1f, 0.25f);
 						Vector2 velocity = playerVelocity + position * 1.25f;
 						position = position * 8 + playerOffset;
-						Dust dust = Dust.NewDustPerfect(position, mod.DustType("MiceDust"), velocity);
+						Dust dust = Dust.NewDustPerfect(position, ModContent.DustType<MiceDust>(), velocity);
 						dust.noGravity = true;
 						dust.scale = 0.8f + rate * 0.04f;
 						dust.shader = GameShaders.Armor.GetSecondaryShader(player.cWings, player);
@@ -104,7 +105,7 @@ namespace ClickerClass.Items.Accessories
 						Vector2 position = -Vector2.UnitY.RotatedBy(i * MathHelper.TwoPi / numDusts) * new Vector2(1f, 0.25f);
 						Vector2 velocity = playerVelocity + position * 2;
 						position = position * 8 + playerOffset;
-						Dust dust = Dust.NewDustPerfect(position, mod.DustType("MiceDust"), velocity);
+						Dust dust = Dust.NewDustPerfect(position, ModContent.DustType<MiceDust>(), velocity);
 						dust.noGravity = true;
 						dust.fadeIn = 1f;
 						dust.scale = 0.8f;

--- a/Items/Accessories/TheScroller.cs
+++ b/Items/Accessories/TheScroller.cs
@@ -119,7 +119,7 @@ namespace ClickerClass.Items.Accessories
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "MiceFragment", 14);
+			recipe.AddIngredient(ModContent.ItemType<MiceFragment>(), 14);
 			recipe.AddIngredient(ItemID.LunarBar, 10);
 			recipe.AddTile(TileID.LunarCraftingStation);
 			recipe.SetResult(this);

--- a/Items/Armors/MiceBoots.cs
+++ b/Items/Armors/MiceBoots.cs
@@ -33,7 +33,7 @@ namespace ClickerClass.Items.Armors
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "MiceFragment", 15);
+			recipe.AddIngredient(ModContent.ItemType<MiceFragment>(), 15);
 			recipe.AddIngredient(ItemID.LunarBar, 12);
 			recipe.AddTile(TileID.LunarCraftingStation);
 			recipe.SetResult(this);

--- a/Items/Armors/MiceMask.cs
+++ b/Items/Armors/MiceMask.cs
@@ -33,7 +33,7 @@ namespace ClickerClass.Items.Armors
 
 		public override bool IsArmorSet(Item head, Item body, Item legs)
 		{
-			return body.type == mod.ItemType("MiceSuit") && legs.type == mod.ItemType("MiceBoots");
+			return body.type == ModContent.ItemType<MiceSuit>() && legs.type == ModContent.ItemType<MiceBoots>();
 		}
 
 		public override void UpdateArmorSet(Player player)

--- a/Items/Armors/MiceMask.cs
+++ b/Items/Armors/MiceMask.cs
@@ -50,7 +50,7 @@ namespace ClickerClass.Items.Armors
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "MiceFragment", 10);
+			recipe.AddIngredient(ModContent.ItemType<MiceFragment>(), 10);
 			recipe.AddIngredient(ItemID.LunarBar, 8);
 			recipe.AddTile(TileID.LunarCraftingStation);
 			recipe.SetResult(this);

--- a/Items/Armors/MiceSuit.cs
+++ b/Items/Armors/MiceSuit.cs
@@ -34,7 +34,7 @@ namespace ClickerClass.Items.Armors
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "MiceFragment", 20);
+			recipe.AddIngredient(ModContent.ItemType<MiceFragment>(), 20);
 			recipe.AddIngredient(ItemID.LunarBar, 16);
 			recipe.AddTile(TileID.LunarCraftingStation);
 			recipe.SetResult(this);

--- a/Items/Armors/MotherboardHelmet.cs
+++ b/Items/Armors/MotherboardHelmet.cs
@@ -30,7 +30,7 @@ namespace ClickerClass.Items.Armors
 
 		public override bool IsArmorSet(Item head, Item body, Item legs)
 		{
-			return body.type == mod.ItemType("MotherboardSuit") && legs.type == mod.ItemType("MotherboardBoots");
+			return body.type == ModContent.ItemType<MotherboardSuit>() && legs.type == ModContent.ItemType<MotherboardBoots>();
 		}
 
 		public override void UpdateArmorSet(Player player)

--- a/Items/Armors/OverclockHelmet.cs
+++ b/Items/Armors/OverclockHelmet.cs
@@ -30,7 +30,7 @@ namespace ClickerClass.Items.Armors
 
 		public override bool IsArmorSet(Item head, Item body, Item legs)
 		{
-			return body.type == mod.ItemType("OverclockSuit") && legs.type == mod.ItemType("OverclockBoots");
+			return body.type == ModContent.ItemType<OverclockSuit>() && legs.type == ModContent.ItemType<OverclockBoots>();
 		}
 
 		public override void UpdateArmorSet(Player player)

--- a/Items/Armors/PrecursorHelmet.cs
+++ b/Items/Armors/PrecursorHelmet.cs
@@ -30,7 +30,7 @@ namespace ClickerClass.Items.Armors
 
 		public override bool IsArmorSet(Item head, Item body, Item legs)
 		{
-			return body.type == mod.ItemType("PrecursorBreastplate") && legs.type == mod.ItemType("PrecursorGreaves");
+			return body.type == ModContent.ItemType<PrecursorBreastplate>() && legs.type == ModContent.ItemType<PrecursorGreaves>();
 		}
 
 		public override void UpdateArmorSet(Player player)

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -1,4 +1,5 @@
 ﻿using ClickerClass.Buffs;
+using ClickerClass.Dusts;
 using ClickerClass.Prefixes;
 using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
@@ -357,7 +358,7 @@ namespace ClickerClass.Items
 									Vector2 vector12 = Vector2.UnitX * 0f;
 									vector12 += -Vector2.UnitY.RotatedBy((double)((float)num103 * (6.28318548f / num102)), default(Vector2)) * new Vector2(2f, 2f);
 									vector12 = vector12.RotatedBy((double)Vector2.Zero.ToRotation(), default(Vector2));
-									int num104 = Dust.NewDust(Main.MouseWorld, 0, 0, mod.DustType("MiceDust"), 0f, 0f, 0, default(Color), 2f);
+									int num104 = Dust.NewDust(Main.MouseWorld, 0, 0, ModContent.DustType<MiceDust>(), 0f, 0f, 0, default(Color), 2f);
 									Main.dust[num104].noGravity = true;
 									Main.dust[num104].position = Main.MouseWorld + vector12;
 									Main.dust[num104].velocity = Vector2.Zero * 0f + vector12.SafeNormalize(Vector2.UnitY) * 4f;
@@ -403,7 +404,7 @@ namespace ClickerClass.Items
 				if (clickerPlayer.clickAmount % 100 == 0 && clickerPlayer.setOverclock)
 				{
 					Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 94);
-					player.AddBuff(mod.BuffType("OverclockBuff"), 180, false);
+					player.AddBuff(ModContent.BuffType<OverclockBuff>(), 180, false);
 					for (int i = 0; i < 25; i++)
 					{
 						int num6 = Dust.NewDust(player.position, 20, 20, 90, 0f, 0f, 150, default(Color), 1.35f);
@@ -647,7 +648,7 @@ namespace ClickerClass.Items
 					if (itemClickerEffect.Contains("Haste") || wildMagic == 11)
 					{
 						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
-						player.AddBuff(mod.BuffType("Haste"), 300, false);
+						player.AddBuff(ModContent.BuffType<Haste>(), 300, false);
 						for (int i = 0; i < 15; i++)
 						{
 							int num6 = Dust.NewDust(player.position, 20, 20, 56, 0f, 0f, 150, default(Color), 1.25f);
@@ -671,7 +672,7 @@ namespace ClickerClass.Items
 						player.AddBuff(BuffID.RapidHealing, 120, false);
 						for (int i = 0; i < 15; i++)
 						{
-							int num6 = Dust.NewDust(player.position, 20, 20, mod.DustType("LoveDust"), 0f, 0f, 0, Color.White, 1f);
+							int num6 = Dust.NewDust(player.position, 20, 20, ModContent.DustType<LoveDust>(), 0f, 0f, 0, Color.White, 1f);
 							Main.dust[num6].noGravity = true;
 							Main.dust[num6].velocity *= 0.75f;
 							int num7 = Main.rand.Next(-50, 51);
@@ -854,7 +855,7 @@ namespace ClickerClass.Items
 					{
 						clickerPlayer.clickAmount++;
 						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
-						player.AddBuff(mod.BuffType("AutoClick"), 300, false);
+						player.AddBuff(ModContent.BuffType<AutoClick>(), 300, false);
 						for (int i = 0; i < 15; i++)
 						{
 							int num6 = Dust.NewDust(player.position, 20, 20, 15, 0f, 0f, 255, default(Color), 1.5f);
@@ -903,7 +904,7 @@ namespace ClickerClass.Items
 						}
 						for (int k = 0; k < 10; k++)
 						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, mod.DustType("MiceDust"), Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
+							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, ModContent.DustType<MiceDust>(), Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
 							dust.noGravity = true;
 						}
 					}
@@ -915,7 +916,7 @@ namespace ClickerClass.Items
 						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<AstralClickerPro>(), (int)(damage * 3f), 0f, player.whoAmI);
 						for (int k = 0; k < 20; k++)
 						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, mod.DustType("MiceDust"), Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
+							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, ModContent.DustType<MiceDust>(), Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
 							dust.noGravity = true;
 						}
 					}

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -164,7 +164,7 @@ namespace ClickerClass.Items
 		{
 			if (ClickerSystem.IsClickerWeapon(item))
 			{
-				crit = item.crit + player.GetModPlayer<ClickerPlayer>().clickerCrit;
+				crit += player.GetModPlayer<ClickerPlayer>().clickerCrit;
 			}
 		}
 

--- a/Items/Consumables/InfluencePotion.cs
+++ b/Items/Consumables/InfluencePotion.cs
@@ -1,3 +1,4 @@
+using ClickerClass.Buffs;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -26,7 +27,7 @@ namespace ClickerClass.Items.Consumables
 			item.maxStack = 30;
 			item.rare = 1;
 			item.UseSound = SoundID.Item3;
-			item.buffType = mod.BuffType("InfluenceBuff");
+			item.buffType = ModContent.BuffType<InfluenceBuff>();
 			item.buffTime = 18000;
 		}
 

--- a/Items/Tools/MiceHamaxe.cs
+++ b/Items/Tools/MiceHamaxe.cs
@@ -34,7 +34,7 @@ namespace ClickerClass.Items.Tools
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "MiceFragment", 14);
+			recipe.AddIngredient(ModContent.ItemType<MiceFragment>(), 14);
 			recipe.AddIngredient(ItemID.LunarBar, 12);
 			recipe.AddTile(TileID.LunarCraftingStation);
 			recipe.SetResult(this);

--- a/Items/Tools/MicePickaxe.cs
+++ b/Items/Tools/MicePickaxe.cs
@@ -33,7 +33,7 @@ namespace ClickerClass.Items.Tools
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "MiceFragment", 12);
+			recipe.AddIngredient(ModContent.ItemType<MiceFragment>(), 12);
 			recipe.AddIngredient(ItemID.LunarBar, 10);
 			recipe.AddTile(TileID.LunarCraftingStation);
 			recipe.SetResult(this);

--- a/Items/Weapons/Clickers/AstralClicker.cs
+++ b/Items/Weapons/Clickers/AstralClicker.cs
@@ -33,7 +33,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "MiceFragment", 18);
+			recipe.AddIngredient(ModContent.ItemType<MiceFragment>(), 18);
 			recipe.AddTile(TileID.LunarCraftingStation);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/Items/Weapons/Clickers/AstralClicker.cs
+++ b/Items/Weapons/Clickers/AstralClicker.cs
@@ -1,3 +1,4 @@
+using ClickerClass.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
@@ -18,7 +19,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			base.SetDefaults();
 			SetRadius(item, 6f);
 			SetColor(item, new Color(150, 150, 225, 0));
-			SetDust(item, mod.DustType("MiceDust"));
+			SetDust(item, ModContent.DustType<MiceDust>());
 			SetAmount(item, 15);
 			SetEffect(item, "Spiral");
 

--- a/Items/Weapons/Clickers/HoneyGlazedClicker.cs
+++ b/Items/Weapons/Clickers/HoneyGlazedClicker.cs
@@ -1,3 +1,4 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -28,7 +29,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			item.knockBack = 2f;
 			item.value = 10000;
 			item.rare = 3;
-			item.shoot = mod.ProjectileType("HoneyGlazedClickerPro");
+			item.shoot = ModContent.ProjectileType<HoneyGlazedClickerPro>();
 		}
 
 		public override void AddRecipes()

--- a/Items/Weapons/Clickers/MiceClicker.cs
+++ b/Items/Weapons/Clickers/MiceClicker.cs
@@ -35,7 +35,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "MiceFragment", 18);
+			recipe.AddIngredient(ModContent.ItemType<MiceFragment>(), 18);
 			recipe.AddTile(TileID.LunarCraftingStation);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/Items/Weapons/Clickers/MiceClicker.cs
+++ b/Items/Weapons/Clickers/MiceClicker.cs
@@ -1,3 +1,4 @@
+using ClickerClass.Dusts;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
@@ -18,7 +19,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			base.SetDefaults();
 			SetRadius(item, 6f);
 			SetColor(item, new Color(150, 150, 225, 0));
-			SetDust(item, mod.DustType("MiceDust"));
+			SetDust(item, ModContent.DustType<MiceDust>());
 			SetAmount(item, 10);
 			SetEffect(item, "Collision");
 

--- a/Items/Weapons/Clickers/UmbralClicker.cs
+++ b/Items/Weapons/Clickers/UmbralClicker.cs
@@ -1,4 +1,6 @@
 using Microsoft.Xna.Framework;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -32,18 +34,18 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void AddRecipes()
 		{
 			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "DarkClicker", 1);
-			recipe.AddIngredient(null, "SlickClicker", 1);
-			recipe.AddIngredient(null, "PointyClicker", 1);
-			recipe.AddIngredient(null, "RedHotClicker", 1);
+			recipe.AddIngredient(ModContent.ItemType<DarkClicker>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<SlickClicker>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<PointyClicker>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<RedHotClicker>(), 1);
 			recipe.AddTile(TileID.DemonAltar);
 			recipe.SetResult(this);
 			recipe.AddRecipe();
 			recipe = new ModRecipe(mod);
-			recipe.AddIngredient(null, "SinisterClicker", 1);
-			recipe.AddIngredient(null, "SlickClicker", 1);
-			recipe.AddIngredient(null, "PointyClicker", 1);
-			recipe.AddIngredient(null, "RedHotClicker", 1);
+			recipe.AddIngredient(ModContent.ItemType<SinisterClicker>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<SlickClicker>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<PointyClicker>(), 1);
+			recipe.AddIngredient(ModContent.ItemType<RedHotClicker>(), 1);
 			recipe.AddTile(TileID.DemonAltar);
 			recipe.SetResult(this);
 			recipe.AddRecipe();

--- a/NPCs/ClickerGlobalNPC.cs
+++ b/NPCs/ClickerGlobalNPC.cs
@@ -1,3 +1,7 @@
+using ClickerClass.Buffs;
+using ClickerClass.Items;
+using ClickerClass.Items.Accessories;
+using ClickerClass.Items.Weapons.Clickers;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.Graphics.Shaders;
@@ -85,8 +89,8 @@ namespace ClickerClass.NPCs
 				case NPCID.DD2OgreT2:
 				case NPCID.DD2OgreT3:
 				case NPCID.TargetDummy:
-					npc.buffImmune[mod.BuffType("Frozen")] = true;
-					npc.buffImmune[mod.BuffType("HoneySlow")] = true;
+					npc.buffImmune[ModContent.BuffType<Frozen>()] = true;
+					npc.buffImmune[ModContent.BuffType<HoneySlow>()] = true;
 					break;
 				default:
 					if (npc.boss)
@@ -123,88 +127,88 @@ namespace ClickerClass.NPCs
 			{
 				if (Main.rand.NextBool(20))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("ShadowyClicker"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<ShadowyClicker>(), 1, false, -1);
 				}
 			}
 			if ((npc.type == NPCID.Frankenstein || npc.type == NPCID.SwampThing) && npc.value > 0f)
 			{
 				if (Main.rand.NextBool(25))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("EclipticClicker"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<EclipticClicker>(), 1, false, -1);
 				}
 			}
 			if ((npc.type == NPCID.BloodZombie || npc.type == NPCID.Drippler) && npc.value > 0f)
 			{
 				if (Main.rand.NextBool(25))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("HemoClicker"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<HemoClicker>(), 1, false, -1);
 				}
 			}
 			if (npc.type == NPCID.DarkCaster)
 			{
 				if (Main.rand.NextBool(15))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("Milk"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<Milk>(), 1, false, -1);
 				}
 			}
 			if (npc.type == NPCID.Gastropod)
 			{
 				if (Main.rand.NextBool(20))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("ChocolateChip"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<ChocolateChip>(), 1, false, -1);
 				}
 			}
 			if (npc.type == NPCID.PirateCaptain)
 			{
 				if (Main.rand.NextBool(8))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("CaptainsClicker"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<CaptainsClicker>(), 1, false, -1);
 				}
 			}
 			if (npc.type == NPCID.Pumpking)
 			{
 				if (Main.rand.NextBool(10))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("WitchClicker"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<WitchClicker>(), 1, false, -1);
 				}
 			}
 			if (npc.type == NPCID.IceQueen)
 			{
 				if (Main.rand.NextBool(10))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("FrozenClicker"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<FrozenClicker>(), 1, false, -1);
 				}
 			}
 			if (npc.type == NPCID.MartianSaucerCore)
 			{
 				if (Main.rand.NextBool(4))
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("HighTechClicker"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<HighTechClicker>(), 1, false, -1);
 				}
 			}
 			if (!Main.expertMode)
 			{
 				if (npc.type == NPCID.MoonLordCore)
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("LordsClicker"), 1, false, -1);
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<LordsClicker>(), 1, false, -1);
 
 					if (Main.rand.NextBool(5))
 					{
-						Item.NewItem(npc.Hitbox, mod.ItemType("TheClicker"), 1, false, -1);
+						Item.NewItem(npc.Hitbox, ModContent.ItemType<TheClicker>(), 1, false, -1);
 					}
 				}
 				if (npc.type == NPCID.WallofFlesh)
 				{
 					if (Main.rand.NextBool(4))
 					{
-						Item.NewItem(npc.Hitbox, mod.ItemType("ClickerEmblem"), 1, false, -1);
+						Item.NewItem(npc.Hitbox, ModContent.ItemType<ClickerEmblem>(), 1, false, -1);
 					}
 				}
 				if (npc.type == NPCID.KingSlime)
 				{
 					if (Main.rand.NextBool(4))
 					{
-						Item.NewItem(npc.Hitbox, mod.ItemType("StickyKeychain"), 1, false, -1);
+						Item.NewItem(npc.Hitbox, ModContent.ItemType<StickyKeychain>(), 1, false, -1);
 					}
 				}
 			}
@@ -212,11 +216,11 @@ namespace ClickerClass.NPCs
 			{
 				if (Main.expertMode)
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("MiceFragment"), Main.rand.Next(5, 23));
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<MiceFragment>(), Main.rand.Next(5, 23));
 				}
 				else
 				{
-					Item.NewItem(npc.Hitbox, mod.ItemType("MiceFragment"), Main.rand.Next(3, 16));
+					Item.NewItem(npc.Hitbox, ModContent.ItemType<MiceFragment>(), Main.rand.Next(3, 16));
 				}
 			}
 		}
@@ -228,19 +232,19 @@ namespace ClickerClass.NPCs
 			switch (type)
 			{
 				case NPCID.Merchant:
-					shop.item[nextSlot++].SetDefaults(mod.ItemType("Cookie"));
+					shop.item[nextSlot++].SetDefaults(ModContent.ItemType<Cookie>());
 					break;
 				case NPCID.TravellingMerchant:
-					shop.item[nextSlot++].SetDefaults(mod.ItemType("Soda"));
+					shop.item[nextSlot++].SetDefaults(ModContent.ItemType<Soda>());
 					break;
 				case NPCID.Mechanic:
-					shop.item[nextSlot++].SetDefaults(mod.ItemType("HandCream"));
+					shop.item[nextSlot++].SetDefaults(ModContent.ItemType<HandCream>());
 					break;
 				case NPCID.GoblinTinkerer:
-					shop.item[nextSlot++].SetDefaults(mod.ItemType("MousePad"));
+					shop.item[nextSlot++].SetDefaults(ModContent.ItemType<MousePad>());
 					break;
 				case NPCID.SkeletonMerchant:
-					shop.item[nextSlot++].SetDefaults(mod.ItemType("CandleClicker"));
+					shop.item[nextSlot++].SetDefaults(ModContent.ItemType<CandleClicker>());
 					break;
 			}
 		}

--- a/Projectiles/AstralClickerPro.cs
+++ b/Projectiles/AstralClickerPro.cs
@@ -1,8 +1,10 @@
+using ClickerClass.Dusts;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using Terraria;
 using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Projectiles
 {
@@ -50,7 +52,7 @@ namespace ClickerClass.Projectiles
 			for (int k = 0; k < 1; k++)
 			{
 				Vector2 offset = new Vector2(Main.rand.Next(-100, 101), Main.rand.Next(-100, 101));
-				Dust dust = Dust.NewDustDirect(new Vector2(projectile.Center.X - 10, projectile.Center.Y - 10) + offset, 20, 20, mod.DustType("MiceDust"), Scale: 1.5f);
+				Dust dust = Dust.NewDustDirect(new Vector2(projectile.Center.X - 10, projectile.Center.Y - 10) + offset, 20, 20, ModContent.DustType<MiceDust>(), Scale: 1.5f);
 				dust.noGravity = true;
 				dust.velocity = -offset * 0.1f;
 			}
@@ -81,7 +83,7 @@ namespace ClickerClass.Projectiles
 
 				for (int k = 0; k < 30; k++)
 				{
-					Dust dust = Dust.NewDustDirect(projectile.Center, 10, 10, mod.DustType("MiceDust"), Main.rand.NextFloat(-8f, 8f), Main.rand.NextFloat(-8f, 8f), 0, default, 1.5f);
+					Dust dust = Dust.NewDustDirect(projectile.Center, 10, 10, ModContent.DustType<MiceDust>(), Main.rand.NextFloat(-8f, 8f), Main.rand.NextFloat(-8f, 8f), 0, default, 1.5f);
 					dust.noGravity = true;
 				}
 				for (int k = 0; k < 20; k++)

--- a/Projectiles/BoneClickerPro.cs
+++ b/Projectiles/BoneClickerPro.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Buffs;
 using Terraria;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Projectiles
 {
@@ -20,7 +22,7 @@ namespace ClickerClass.Projectiles
 
 		public override void OnHitNPC(NPC target, int damage, float knockback, bool crit)
 		{
-			target.AddBuff(mod.BuffType("Gouge"), 60, false);
+			target.AddBuff(ModContent.BuffType<Gouge>(), 60, false);
 		}
 	}
 }

--- a/Projectiles/FrozenClickerPro.cs
+++ b/Projectiles/FrozenClickerPro.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Buffs;
 using Terraria;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Projectiles
 {
@@ -20,7 +22,7 @@ namespace ClickerClass.Projectiles
 
 		public override void OnHitNPC(NPC target, int damage, float knockback, bool crit)
 		{
-			target.AddBuff(mod.BuffType("Frozen"), 120, false);
+			target.AddBuff(ModContent.BuffType<Frozen>(), 120, false);
 		}
 
 		public override void Kill(int timeLeft)

--- a/Projectiles/HoneyGlazedClickerPro.cs
+++ b/Projectiles/HoneyGlazedClickerPro.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Buffs;
 using Terraria;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Projectiles
 {
@@ -20,7 +22,7 @@ namespace ClickerClass.Projectiles
 
 		public override void OnHitNPC(NPC target, int damage, float knockback, bool crit)
 		{
-			target.AddBuff(mod.BuffType("HoneySlow"), 90, false);
+			target.AddBuff(ModContent.BuffType<HoneySlow>(), 90, false);
 		}
 
 		public override void Kill(int timeLeft)

--- a/Projectiles/MiceClickerPro.cs
+++ b/Projectiles/MiceClickerPro.cs
@@ -1,6 +1,8 @@
+using ClickerClass.Dusts;
 using Microsoft.Xna.Framework;
 using System;
 using Terraria;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Projectiles
 {
@@ -34,7 +36,7 @@ namespace ClickerClass.Projectiles
 			{
 				float num364 = projectile.velocity.X / 3f * (float)num363;
 				float num365 = projectile.velocity.Y / 3f * (float)num363;
-				int num366 = Dust.NewDust(projectile.Center, projectile.width, projectile.height, mod.DustType("MiceDust"), 0f, 0f, 0, default(Color), 1f);
+				int num366 = Dust.NewDust(projectile.Center, projectile.width, projectile.height, ModContent.DustType<MiceDust>(), 0f, 0f, 0, default(Color), 1f);
 				Main.dust[num366].position.X = projectile.Center.X - num364;
 				Main.dust[num366].position.Y = projectile.Center.Y - num365;
 				Main.dust[num366].velocity *= 0f;
@@ -87,7 +89,7 @@ namespace ClickerClass.Projectiles
 		{
 			for (int k = 0; k < 5; k++)
 			{
-				Dust dust = Dust.NewDustDirect(projectile.Center, 10, 10, mod.DustType("MiceDust"), Main.rand.NextFloat(-3f, 3f), Main.rand.NextFloat(-3f, 3f), 0, default, 1f);
+				Dust dust = Dust.NewDustDirect(projectile.Center, 10, 10, ModContent.DustType<MiceDust>(), Main.rand.NextFloat(-3f, 3f), Main.rand.NextFloat(-3f, 3f), 0, default, 1f);
 				dust.noGravity = true;
 			}
 		}

--- a/Projectiles/MythrilClickerPro.cs
+++ b/Projectiles/MythrilClickerPro.cs
@@ -1,6 +1,8 @@
+using ClickerClass.Buffs;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.Graphics.Shaders;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Projectiles
 {
@@ -31,7 +33,7 @@ namespace ClickerClass.Projectiles
 					NPC target = Main.npc[u];
 					if (target.CanBeChasedBy(projectile) && target.DistanceSQ(projectile.Center) < 250 * 250)
 					{
-						target.AddBuff(mod.BuffType("Embrittle"), 240, false);
+						target.AddBuff(ModContent.BuffType<Embrittle>(), 240, false);
 
 						for (int i = 0; i < 15; i++)
 						{

--- a/Projectiles/TotalityClickerPro.cs
+++ b/Projectiles/TotalityClickerPro.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using Terraria;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Projectiles
 {
@@ -73,7 +74,7 @@ namespace ClickerClass.Projectiles
 						for (int i = 0; i < numberProjectiles; i++)
 						{
 							Vector2 perturbedSpeed = new Vector2(vector.X, vector.Y).RotatedBy(MathHelper.Lerp(-rotation, rotation, i / (numberProjectiles - 1))) * 1f;
-							Projectile.NewProjectile(projectile.Center, perturbedSpeed, mod.ProjectileType("TotalityClickerPro2"), (int)(projectile.damage * 0.25f), projectile.knockBack, projectile.owner);
+							Projectile.NewProjectile(projectile.Center, perturbedSpeed, ModContent.ProjectileType<TotalityClickerPro2>(), (int)(projectile.damage * 0.25f), projectile.knockBack, projectile.owner);
 						}
 					}
 				}


### PR DESCRIPTION
Fixes GetWeaponCrit compatibility with other mods

Also turns all content references using string access into generics, guaranteeing type safety and cleaner programming style. This is especially important for further porting the mod to 1.4 where string access is less favored within the mod itself (aka not cross mod).

Not worth an update just for this, as an effect rework is in the works which will make the API more powerful.

For the changelog nonetheless:
* Fixed compatibility with other mods when adjusting crit on clickers