### PR TITLE
Click effect rework, some fixes, more API

### DIFF
--- a/ClickEffect.cs
+++ b/ClickEffect.cs
@@ -56,6 +56,11 @@ namespace ClickerClass
 			return new TooltipLine(ClickerClass.mod, $"ClickEffect:{InternalName}", text);
 		}
 
+		public override string ToString()
+		{
+			return $"{InternalName} / {DisplayName}: {Description.Substring(0, 20)}...";
+		}
+
 		public Dictionary<string, object> ToDictionary()
 		{
 			return new Dictionary<string, object>
@@ -76,15 +81,19 @@ namespace ClickerClass
 		{
 			ClickEffect.DoubleClick = ClickerSystem.RegisterClickEffect(ClickerClass.mod, "DoubleClick", "Double Click", "Deals damage twice with one attack", 10, Color.White, delegate (Player player, Vector2 position, int type, int damage, float knockBack)
 			{
-				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 37);
-				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, type, damage, knockBack, player.whoAmI);
+				DoubleClick(player, position, type, damage, knockBack);
 			});
 
 			ClickEffect.DoubleClick2 = ClickerSystem.RegisterClickEffect(ClickerClass.mod, "DoubleClick2", "Double Click", "Deals damage twice with one attack", 8, Color.White, delegate (Player player, Vector2 position, int type, int damage, float knockBack)
 			{
+				DoubleClick(player, position, type, damage, knockBack);
+			});
+
+			void DoubleClick(Player player, Vector2 position, int type, int damage, float knockBack)
+			{
 				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 37);
 				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, type, damage, knockBack, player.whoAmI);
-			});
+			}
 		}
 
 		#region Registered Effects

--- a/ClickEffect.cs
+++ b/ClickEffect.cs
@@ -36,7 +36,7 @@ namespace ClickerClass
 			return new ClickEffect(InternalName, DisplayName, Description, Amount, Color, (Action<Player, Vector2, int, int, float>)Action.Clone());
 		}
 
-		public TooltipLine ToTooltip(int amount, float alpha)
+		public TooltipLine ToTooltip(int amount, float alpha, bool showDesc)
 		{
 			string color = (Color * alpha).Hex3();
 			string text;
@@ -48,7 +48,11 @@ namespace ClickerClass
 			{
 				text = "1 click: ";
 			}
-			text += $"[c/" + color + ":" + DisplayName + "] - " + Description;
+			text += $"[c/" + color + ":" + DisplayName + "]";
+			if (showDesc)
+			{
+				text  += $" - {Description}";
+			}
 			return new TooltipLine(ClickerClass.mod, $"ClickEffect:{InternalName}", text);
 		}
 

--- a/ClickEffect.cs
+++ b/ClickEffect.cs
@@ -1,0 +1,137 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace ClickerClass
+{
+	public sealed class ClickEffect : ICloneable
+	{
+		public string InternalName { get; private set; }
+
+		public string DisplayName { get; private set; }
+
+		public string Description { get; private set; }
+
+		public int Amount { get; private set; }
+
+		public Color Color { get; private set; }
+
+		public Action<Player, Vector2, int, int, float> Action { get; private set; }
+
+		public ClickEffect(string internalName, string displayName, string description, int amount, Color color, Action<Player, Vector2, int, int, float> action)
+		{
+			InternalName = internalName;
+			DisplayName = displayName;
+			Description = description;
+			Amount = amount;
+			Color = color;
+			Action = action ?? (new Action<Player, Vector2, int, int, float>((a, b, c, d, e) => { }));
+		}
+
+		public object Clone()
+		{
+			return new ClickEffect(InternalName, DisplayName, Description, Amount, Color, (Action<Player, Vector2, int, int, float>)Action.Clone());
+		}
+
+		public TooltipLine ToTooltip(int amount, float alpha)
+		{
+			string color = (Color * alpha).Hex3();
+			string text;
+			if (amount > 1)
+			{
+				text = $"{amount} clicks: ";
+			}
+			else
+			{
+				text = "1 click: ";
+			}
+			text += $"[c/" + color + ":" + DisplayName + "] - " + Description;
+			return new TooltipLine(ClickerClass.mod, $"ClickEffect:{InternalName}", text);
+		}
+
+		public Dictionary<string, object> ToDictionary()
+		{
+			return new Dictionary<string, object>
+			{
+				["InternalName"] = InternalName,
+				["DisplayName"] = DisplayName,
+				["Description"] = Description,
+				["Amount"] = Amount,
+				["Color"] = Color,
+				["Action"] = Action
+			};
+		}
+
+		/// <summary>
+		/// Loads commonly used click effects
+		/// </summary>
+		internal static void LoadMiscEffects()
+		{
+			ClickEffect.DoubleClick = ClickerSystem.RegisterClickEffect(ClickerClass.mod, "DoubleClick", "Double Click", "Deals damage twice with one attack", 10, Color.White, delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 37);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, type, damage, knockBack, player.whoAmI);
+			});
+
+			ClickEffect.DoubleClick2 = ClickerSystem.RegisterClickEffect(ClickerClass.mod, "DoubleClick2", "Double Click", "Deals damage twice with one attack", 8, Color.White, delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 37);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, type, damage, knockBack, player.whoAmI);
+			});
+		}
+
+		#region Registered Effects
+		//Acc
+		public static string StickyKeychain { get; internal set; } = string.Empty;
+		public static string ChocolateChip { get; internal set; } = string.Empty;
+
+		//Clicker
+		public static string TrueStrike { get; internal set; } = string.Empty;
+		public static string HolyNova { get; internal set; } = string.Empty;
+		public static string Spiral { get; internal set; } = string.Empty;
+		public static string Lacerate { get; internal set; } = string.Empty;
+		public static string Illuminate { get; internal set; } = string.Empty;
+		public static string Bombard { get; internal set; } = string.Empty;
+		public static string ToxicRelease { get; internal set; } = string.Empty;
+		public static string Haste { get; internal set; } = string.Empty;
+		public static string DoubleClick { get; internal set; } = string.Empty;
+		public static string DoubleClick2 { get; internal set; } = string.Empty;
+		public static string CursedEruption { get; internal set; } = string.Empty;
+		public static string Infest { get; internal set; } = string.Empty;
+		public static string Dazzle { get; internal set; } = string.Empty;
+		public static string DarkBurst { get; internal set; } = string.Empty;
+		public static string Totality { get; internal set; } = string.Empty;
+		public static string Freeze { get; internal set; } = string.Empty;
+		public static string Linger { get; internal set; } = string.Empty;
+		public static string Discharge { get; internal set; } = string.Empty;
+		public static string StickyHoney { get; internal set; } = string.Empty;
+		public static string SolarFlare { get; internal set; } = string.Empty;
+		public static string Conqueror { get; internal set; } = string.Empty;
+		public static string Collision { get; internal set; } = string.Empty;
+		public static string Embrittle { get; internal set; } = string.Empty;
+		public static string PetalStorm { get; internal set; } = string.Empty;
+		public static string Regenerate { get; internal set; } = string.Empty;
+		public static string StingingThorn { get; internal set; } = string.Empty;
+		public static string Inferno { get; internal set; } = string.Empty;
+		public static string Curse { get; internal set; } = string.Empty;
+		public static string AutoClick { get; internal set; } = string.Empty;
+		public static string Siphon { get; internal set; } = string.Empty;
+		public static string Splash { get; internal set; } = string.Empty;
+		public static string StarStorm { get; internal set; } = string.Empty;
+		public static string PhaseReach { get; internal set; } = string.Empty;
+		public static string TheClick { get; internal set; } = string.Empty;
+		public static string RazorsEdge { get; internal set; } = string.Empty;
+		public static string ShadowLash { get; internal set; } = string.Empty;
+		public static string WildMagic { get; internal set; } = string.Empty;
+		#endregion
+
+		public static void Unload()
+		{
+			//Invokes the static constructor to redefine 'Registered Effects'
+			typeof(ClickEffect).TypeInitializer?.Invoke(null, null);
+		}
+	}
+}

--- a/ClickerClass.cs
+++ b/ClickerClass.cs
@@ -1,8 +1,6 @@
 using ClickerClass.Effects;
-using ClickerClass.Items;
 using ClickerClass.UI;
 using Microsoft.Xna.Framework;
-using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.ModLoader;
@@ -26,6 +24,7 @@ namespace ClickerClass
 			mod = this;
 			AutoClickKey = RegisterHotKey("Clicker Accessory", "G");
 			ClickerSystem.Load();
+			ClickEffect.LoadMiscEffects();
 
 			if (!Main.dedServ)
 			{
@@ -38,6 +37,7 @@ namespace ClickerClass
 			finalizedRegisterCompat = false;
 			ShaderManager.Unload();
 			ClickerSystem.Unload();
+			ClickEffect.Unload();
 			ClickerInterfaceResources.Unload();
 			AutoClickKey = null;
 			mod = null;

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -293,6 +293,10 @@ namespace ClickerClass
 					{
 						return clickerPlayer.clickAmount;
 					}
+					else if (statName == "clickerPerSecond")
+					{
+						return clickerPlayer.clickerPerSecond;
+					}
 					//TODO clickerPerSecond
 
 					throw new Exception($"Call Error: The statName argument for the attempted message, \"{message}\" has no valid entry point.");

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -172,6 +172,16 @@ namespace ClickerClass
 						throw new Exception($"Call Error: The item/type argument for the attempted message, \"{message}\" has returned null.");
 					}
 				}
+				else if (message == "IsClickEffect")
+				{
+					var effectName = args[index + 0] as string;
+
+					if (effectName == null)
+					{
+						throw new Exception($"Call Error: The effectName argument for the attempted message, \"{message}\" has returned null.");
+					}
+					return ClickerSystem.IsClickEffect(effectName);
+				}
 				//Clicker Weapon/Item specifics now
 				else if (message == "SetColor")
 				{
@@ -282,6 +292,23 @@ namespace ClickerClass
 					{
 						throw new Exception($"Call Error: The name/names argument for the attempted message, \"{message}\" has returned null.");
 					}
+				}
+				else if (message == "GetAllEffectNames")
+				{
+					//IEnumerable<string>
+					return ClickerSystem.GetAllEffectNames();
+				}
+				else if (message == "GetClickEffectAsDict")
+				{
+					var effectName = args[index + 0] as string;
+
+					if (effectName == null)
+					{
+						throw new Exception($"Call Error: The effectName argument for the attempted message, \"{message}\" has returned null.");
+					}
+
+					//Dictionary<string, object>
+					return ClickerSystem.GetClickEffectAsDict(effectName);
 				}
 				//Player specifics now
 				else if (message == "GetPlayerStat")

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -331,6 +331,7 @@ namespace ClickerClass
 						{
 							name = string.Empty;
 						}
+
 						return clickerPlayer.GetClickAmountTotal(item, name);
 					}
 					else if (statName == "clickAmount")
@@ -341,7 +342,6 @@ namespace ClickerClass
 					{
 						return clickerPlayer.clickerPerSecond;
 					}
-					//TODO clickerPerSecond
 
 					throw new Exception($"Call Error: The statName argument for the attempted message, \"{message}\" has no valid entry point.");
 				}

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -74,6 +74,41 @@ namespace ClickerClass
 					ClickerSystem.RegisterClickerWeapon(modItem);
 					return success;
 				}
+				//Mod mod, string internalName, string displayName, string description, int amount, Color color, Action<Player, Vector2, int, int, float> action
+				else if (message == "RegisterClickEffect")
+				{
+					var mod = args[index + 0] as Mod;
+					var internalName = args[index + 1] as string;
+					var displayName = args[index + 2] as string;
+					var description = args[index + 3] as string;
+					var amount = args[index + 4] as int?;
+					var color = args[index + 5] as Color?;
+					var action = args[index + 6] as Action<Player, Vector2, int, int, float>;
+
+					string nameOfargument = string.Empty;
+					if (mod == null)
+						nameOfargument = "mod";
+					if (internalName == null)
+						nameOfargument = "internalName";
+					if (displayName == null)
+						nameOfargument = "displayName";
+					if (description == null)
+						nameOfargument = "description";
+					if (amount == null)
+						nameOfargument = "amount";
+					if (color == null)
+						nameOfargument = "color";
+					if (action == null)
+						nameOfargument = "action";
+
+					if (nameOfargument != string.Empty)
+					{
+						throw new Exception($"Call Error: The {nameOfargument} argument for the attempted message, \"{message}\" has returned null.");
+					}
+
+					ClickerSystem.RegisterClickEffect(mod, internalName, displayName, description, amount.Value, color.Value, action);
+					return success;
+				}
 				else if (message == "IsClickerProj")
 				{
 					var proj = args[index + 0] as Projectile;
@@ -239,7 +274,6 @@ namespace ClickerClass
 						throw new Exception($"Call Error: The name/names argument for the attempted message, \"{message}\" has returned null.");
 					}
 				}
-				//TODO RegisterClickEffect
 				//Player specifics now
 				else if (message == "GetPlayerStat")
 				{

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -66,12 +66,13 @@ namespace ClickerClass
 				else if (message == "RegisterClickerWeapon")
 				{
 					var modItem = args[index + 0] as ModItem;
+					var borderTexture = args[index + 1] as string;
 					if (modItem == null)
 					{
 						throw new Exception($"Call Error: The modItem argument for the attempted message, \"{message}\" has returned null.");
 					}
 
-					ClickerSystem.RegisterClickerWeapon(modItem);
+					ClickerSystem.RegisterClickerWeapon(modItem, borderTexture);
 					return success;
 				}
 				//Mod mod, string internalName, string displayName, string description, int amount, Color color, Action<Player, Vector2, int, int, float> action
@@ -108,6 +109,15 @@ namespace ClickerClass
 
 					ClickerSystem.RegisterClickEffect(mod, internalName, displayName, description, amount.Value, color.Value, action);
 					return success;
+				}
+				else if (message == "GetPathToBorderTexture")
+				{
+					var type = args[index + 0] as int?;
+					if (type == null)
+					{
+						throw new Exception($"Call Error: The type argument for the attempted message, \"{message}\" has returned null.");
+					}
+					return ClickerSystem.GetPathToBorderTexture(type.Value);
 				}
 				else if (message == "IsClickerProj")
 				{

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -13,7 +13,6 @@ namespace ClickerClass
 		//Not everything is exposed via API yet
 		public static object Call(params object[] args)
 		{
-			//TODO update calls for new API
 			ClickerClass clickerClass = ClickerClass.mod;
 			Version latestVersion = clickerClass.Version;
 			//Simplify code by resizing args

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -565,8 +565,52 @@ namespace ClickerClass
 
 					throw new Exception($"Call Error: The accName argument for the attempted message, \"{message}\" has no valid entry point.");
 				}
-				//TODO EnableClickEffect
-				//TODO HasClickEffect
+				else if (message == "EnableClickEffect")
+				{
+					var player = args[index + 0] as Player;
+
+					if (player == null)
+					{
+						throw new Exception($"Call Error: The player argument for the attempted message, \"{message}\" has returned null.");
+					}
+
+					ClickerPlayer clickerPlayer = player.GetModPlayer<ClickerPlayer>();
+
+					var effectName = args[index + 1] as string;
+					var effectNames = args[index + 1] as IEnumerable<string>; //type variation
+
+					if (effectName != null)
+					{
+						clickerPlayer.EnableClickEffect(effectName);
+						return success;
+					}
+					else if (effectNames != null)
+					{
+						clickerPlayer.EnableClickEffect(effectNames);
+						return success;
+					}
+					else
+					{
+						throw new Exception($"Call Error: The effectName/effectNames argument for the attempted message, \"{message}\" has returned null.");
+					}
+				}
+				else if (message == "HasClickEffect")
+				{
+					var player = args[index + 0] as Player;
+					var effectName = args[index + 1] as string;
+
+					if (player == null)
+					{
+						throw new Exception($"Call Error: The player argument for the attempted message, \"{message}\" has returned null.");
+					}
+					if (effectName == null)
+					{
+						throw new Exception($"Call Error: The effectName argument for the attempted message, \"{message}\" has returned null.");
+					}
+
+					ClickerPlayer clickerPlayer = player.GetModPlayer<ClickerPlayer>();
+					return clickerPlayer.HasClickEffect(effectName);
+				}
 			}
 			catch (Exception e)
 			{

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -295,7 +295,7 @@ namespace ClickerClass
 				}
 				else if (message == "GetAllEffectNames")
 				{
-					//IEnumerable<string>
+					//List<string>
 					return ClickerSystem.GetAllEffectNames();
 				}
 				else if (message == "GetClickEffectAsDict")

--- a/ClickerModCalls.cs
+++ b/ClickerModCalls.cs
@@ -1,12 +1,8 @@
-using ClickerClass.Effects;
 using ClickerClass.Items;
-using ClickerClass.UI;
 using Microsoft.Xna.Framework;
 using System;
-using System.Collections.Generic;
 using Terraria;
 using Terraria.ModLoader;
-using Terraria.UI;
 
 namespace ClickerClass
 {
@@ -16,6 +12,7 @@ namespace ClickerClass
 		//Not everything is exposed via API yet
 		public static object Call(params object[] args)
 		{
+			//TODO update calls for new API
 			ClickerClass clickerClass = ClickerClass.mod;
 			//Simplify code by resizing args
 			Array.Resize(ref args, 25);
@@ -142,8 +139,8 @@ namespace ClickerClass
 					{
 						amount = 1;
 					}
-
-					ClickerWeapon.SetAmount(item, amount.Value);
+					//TODO API change
+					//ClickerWeapon.SetAmount(item, amount.Value);
 					return success;
 				}
 				else if (message == "SetColor")
@@ -200,10 +197,10 @@ namespace ClickerClass
 					}
 					if (name == null)
 					{
-						name = ClickerItemCore.NULL;
+						//name = ClickerItemCore.NULL;
 					}
-
-					ClickerWeapon.SetEffect(item, name);
+					//TODO API change
+					//ClickerWeapon.SetEffect(item, name);
 					return success;
 				}
 				else if (message == "SetRadius")
@@ -244,13 +241,14 @@ namespace ClickerClass
 					}
 					else if (statName == "clickAmountTotal")
 					{
+						//TODO API change
 						var item = args[index + 2] as Item;
 						if (item == null)
 						{
 							throw new Exception($"Call Error: The item argument for the attempted message, \"{message}\" has returned null.");
 						}
 
-						return clickerPlayer.GetClickAmountTotal(item);
+						//return clickerPlayer.GetClickAmountTotal(item);
 					}
 					else if (statName == "clickAmount")
 					{
@@ -312,6 +310,7 @@ namespace ClickerClass
 					//accChocolateChip, accEnchantedLED, accEnchantedLED2, accHandCream, accStickyKeychain, accGlassOfMilk, accCookie, accCookie2, accClickingGlove, accAncientClickingGlove, accRegalClickingGlove
 					if (accName == "ChocolateChip")
 					{
+						//TODO API change
 						return clickerPlayer.accChocolateChip;
 					}
 					else if (accName == "EnchantedLED")
@@ -324,6 +323,7 @@ namespace ClickerClass
 					}
 					else if (accName == "StickyKeychain")
 					{
+						//TODO API change
 						return clickerPlayer.accStickyKeychain;
 					}
 					else if (accName == "GlassOfMilk")
@@ -451,6 +451,7 @@ namespace ClickerClass
 					//accChocolateChip, accEnchantedLED, accEnchantedLED2, accHandCream, accStickyKeychain, accGlassOfMilk, accCookie, accCookie2, accClickingGlove, accAncientClickingGlove, accRegalClickingGlove
 					if (accName == "ChocolateChip")
 					{
+						//TODO API change
 						clickerPlayer.accChocolateChip = true;
 						return success;
 					}
@@ -471,6 +472,7 @@ namespace ClickerClass
 					}
 					else if (accName == "StickyKeychain")
 					{
+						//TODO API change
 						clickerPlayer.accStickyKeychain = true;
 						return success;
 					}

--- a/ClickerPlayer.cs
+++ b/ClickerPlayer.cs
@@ -159,6 +159,10 @@ namespace ClickerClass
 		public float ClickerRadiusMotherboard => ClickerRadiusReal * 0.5f;
 
 		//Helper methods
+		/// <summary>
+		/// Enables the use of a click effect for this player
+		/// </summary>
+		/// <param name="name">The unique effect name</param>
 		public void EnableClickEffect(string name)
 		{
 			if (ClickEffectActive.TryGetValue(name, out _))
@@ -167,7 +171,11 @@ namespace ClickerClass
 			}
 		}
 
-		public void EnableClickEffects(List<string> names)
+		/// <summary>
+		/// Enables the use of click effects for this player
+		/// </summary>
+		/// <param name="names">The unique effect names</param>
+		public void EnableClickEffect(IEnumerable<string> names)
 		{
 			foreach (var name in names)
 			{
@@ -175,6 +183,11 @@ namespace ClickerClass
 			}
 		}
 
+		/// <summary>
+		/// Checks if the player has a click effect enabled
+		/// </summary>
+		/// <param name="name">The unique effect name</param>
+		/// <returns><see langword="true"/> if enabled</returns>
 		public bool HasClickEffect(string name)
 		{
 			if (ClickEffectActive.TryGetValue(name, out _))
@@ -184,6 +197,12 @@ namespace ClickerClass
 			return false;
 		}
 
+		/// <summary>
+		/// Checks if the player has a click effect enabled
+		/// </summary>
+		/// <param name="name">The unique effect name</param>
+		/// <param name="effect">The effect associated with the name</param>
+		/// <returns><see langword="true"/> if enabled</returns>
 		public bool HasClickEffect(string name, out ClickEffect effect)
 		{
 			effect = null;
@@ -492,7 +511,7 @@ namespace ClickerClass
 
 			if (ClickerSystem.IsClickerWeapon(player.HeldItem, out ClickerItemCore clickerItem))
 			{
-				EnableClickEffects(clickerItem.itemClickEffects);
+				EnableClickEffect(clickerItem.itemClickEffects);
 				clickerSelected = true;
 				clickerDrawRadius = true;
 				if (HasClickEffect(ClickEffect.PhaseReach))

--- a/ClickerPlayer.cs
+++ b/ClickerPlayer.cs
@@ -236,7 +236,7 @@ namespace ClickerClass
 		/// </summary>
 		private void HandleCPS()
 		{
-			if (clicks.Count < ClickQueueCount)
+			if (clicks.Count < ClickQueueCount - 1)
 			{
 				//Something went very wrong here, backup
 				FillClickQueue();
@@ -244,11 +244,6 @@ namespace ClickerClass
 
 			//Queue can get more than ClickQueueCount: when a click happens
 			clicks.Dequeue();
-
-			if (clicks.Count < ClickQueueCount)
-			{
-				clicks.Enqueue(false);
-			}
 
 			clickerPerSecond = clicks.Count(val => val);
 		}

--- a/ClickerPlayer.cs
+++ b/ClickerPlayer.cs
@@ -27,7 +27,7 @@ namespace ClickerClass
 
 		//-Clicker-
 		//Misc
-		public Color clickerColor = Color.White;
+		public Color clickerRadiusColor = Color.White;
 		/// <summary>
 		/// Visual indicator that the cursor is inside clicker radius
 		/// </summary>
@@ -278,7 +278,7 @@ namespace ClickerClass
 		{
 			//-Clicker-
 			//Misc
-			clickerColor = Color.White;
+			clickerRadiusColor = Color.White;
 			clickerInRange = false;
 			clickerInRangeMotherboard = false;
 			clickerSelected = false;
@@ -480,7 +480,7 @@ namespace ClickerClass
 				{
 					clickerInRangeMotherboard = true;
 				}
-				clickerColor = clickerItem.clickerColorItem;
+				clickerRadiusColor = clickerItem.clickerRadiusColor;
 
 				//Glove acc
 				if (!outOfCombat && (accClickingGlove || accAncientClickingGlove || accRegalClickingGlove))
@@ -992,7 +992,7 @@ namespace ClickerClass
 					Mod mod = ModLoader.GetMod("ClickerClass");
 					float glow = modPlayer.clickerInRangeMotherboard ? 0.6f : 0f;
 
-					Color outer = modPlayer.clickerColor * (0.2f + glow);
+					Color outer = modPlayer.clickerRadiusColor * (0.2f + glow);
 					int drawX = (int)(drawPlayer.Center.X - Main.screenPosition.X);
 					int drawY = (int)(drawPlayer.Center.Y + drawPlayer.gfxOffY - Main.screenPosition.Y);
 					Vector2 center = new Vector2(drawX, drawY);

--- a/ClickerPlayer.cs
+++ b/ClickerPlayer.cs
@@ -99,10 +99,12 @@ namespace ClickerClass
 		public bool SetOverclockDraw => setOverclock && setOverclockAllowed;
 
 		//Acc
+		[Obsolete("Use HasClickEffect(\"ClickerClass:ChocolateChip\") and EnableClickEffect(\"ClickerClass:ChocolateChip\") instead", false)]
 		public bool accChocolateChip = false;
 		public bool accEnchantedLED = false;
 		public bool accEnchantedLED2 = false; //different visuals
 		public bool accHandCream = false;
+		[Obsolete("Use HasClickEffect(\"ClickerClass:StickyKeychain\") and EnableClickEffect(\"ClickerClass:StickyKeychain\") instead", false)]
 		public bool accStickyKeychain = false;
 		public bool accGlassOfMilk = false;
 		public bool accCookie = false;
@@ -341,10 +343,8 @@ namespace ClickerClass
 			setOverclock = false;
 
 			//Acc
-			accChocolateChip = false;
 			accEnchantedLED = false;
 			accEnchantedLED2 = false;
-			accStickyKeychain = false;
 			accHandCream = false;
 			accGlassOfMilk = false;
 			accCookie = false;

--- a/ClickerPlayer.cs
+++ b/ClickerPlayer.cs
@@ -238,7 +238,6 @@ namespace ClickerClass
 		{
 			if (clicks.Count < ClickQueueCount - 1)
 			{
-				//Something went very wrong here, backup
 				FillClickQueue();
 			}
 

--- a/ClickerSystem.cs
+++ b/ClickerSystem.cs
@@ -62,15 +62,21 @@ namespace ClickerClass
 		/// <summary>
 		/// Returns all existing effects' internal names
 		/// </summary>
-		/// <returns>IEnumerable[string]</returns>
-		public static IEnumerable<string> GetAllEffectNames()
+		/// <returns>List[string]</returns>
+		public static List<string> GetAllEffectNames()
 		{
 			//Mod compat version of GetAllEffects() since ClickEffect is an unknown type
-			return GetAllEffects().Keys;
+			return GetAllEffects().Keys.ToList();
 		}
 
 		/// <summary>
-		/// Mod Compat way of accessing an effect's stats. <see cref="null"/> if not found
+		/// Mod Compat way of accessing an effect's stats. <see cref="null"/> if not found.
+		/// "InternalName": The unique name (string).
+		/// | "DisplayName": The displayed name (string).
+		/// | "Description": The description (string).
+		/// | "Amount": The amount of clicks to trigger the effect (int).
+		/// | "Color": The color (Color).
+		/// | "Action": The method ran when triggered (Action[Player, Vector2, int, int, float]).
 		/// </summary>
 		/// <param name="name">The unique name</param>
 		/// <returns>Dictionary[string, object]</returns>

--- a/ClickerSystem.cs
+++ b/ClickerSystem.cs
@@ -114,12 +114,12 @@ namespace ClickerClass
 		/// <param name="amount">The amount of clicks required to trigger the effect</param>
 		/// <param name="action">The method that runs when the effect is triggered</param>
 		/// <returns>The unique identifier</returns>
-		/// <exception cref="UsageException"/>
+		/// <exception cref="InvalidOperationException"/>
 		public static string RegisterClickEffect(Mod mod, string internalName, string displayName, string description, int amount, Color color, Action<Player, Vector2, int, int, float> action)
 		{
 			if (ClickerClass.finalizedRegisterCompat)
 			{
-				throw new UsageException("Tried to register a click effect at the wrong time, do so in Mod.PostSetupContent or ModItem.SetStaticDefaults");
+				throw new InvalidOperationException("Tried to register a click effect at the wrong time, do so in Mod.PostSetupContent or ModItem.SetStaticDefaults");
 			}
 			string name = EffectName(mod, internalName);
 
@@ -132,7 +132,7 @@ namespace ClickerClass
 			}
 			else
 			{
-				throw new UsageException($"The effect '{name}' has already been registered, duplicate detected");
+				throw new InvalidOperationException($"The effect '{name}' has already been registered, duplicate detected");
 			}
 		}
 
@@ -157,12 +157,12 @@ namespace ClickerClass
 		/// Call this in <see cref="ModProjectile.SetStaticDefaults"/> to register this projectile into the "clicker class" category
 		/// </summary>
 		/// <param name="modProj">The <see cref="ModProjectile"/> that is to be registered</param>
-		/// <exception cref="UsageException"/>
+		/// <exception cref="InvalidOperationException"/>
 		public static void RegisterClickerProjectile(ModProjectile modProj)
 		{
 			if (ClickerClass.finalizedRegisterCompat)
 			{
-				throw new UsageException("Tried to register a clicker projectile at the wrong time, do so in ModProjectile.SetStaticDefaults");
+				throw new InvalidOperationException("Tried to register a clicker projectile at the wrong time, do so in ModProjectile.SetStaticDefaults");
 			}
 			int type = modProj.projectile.type;
 			if (!ClickerProjectiles.Contains(type))
@@ -175,12 +175,12 @@ namespace ClickerClass
 		/// Call this in <see cref="ModItem.SetStaticDefaults"/> to register this item into the "clicker class" category
 		/// </summary>
 		/// <param name="modItem">The <see cref="ModItem"/> that is to be registered</param>
-		/// <exception cref="UsageException"/>
+		/// <exception cref="InvalidOperationException"/>
 		public static void RegisterClickerItem(ModItem modItem)
 		{
 			if (ClickerClass.finalizedRegisterCompat)
 			{
-				throw new UsageException("Tried to register a clicker item at the wrong time, do so in ModItem.SetStaticDefaults");
+				throw new InvalidOperationException("Tried to register a clicker item at the wrong time, do so in ModItem.SetStaticDefaults");
 			}
 			int type = modItem.item.type;
 			if (!ClickerItems.Contains(type))
@@ -195,12 +195,12 @@ namespace ClickerClass
 		/// Do not call <see cref="RegisterClickerItem"/> with it as this method does this already by itself
 		/// </summary>
 		/// <param name="modItem">The <see cref="ModItem"/> that is to be registered</param>
-		/// <exception cref="UsageException"/>
+		/// <exception cref="InvalidOperationException"/>
 		public static void RegisterClickerWeapon(ModItem modItem)
 		{
 			if (ClickerClass.finalizedRegisterCompat)
 			{
-				throw new UsageException("Tried to register a clicker weapon at the wrong time, do so in ModItem.SetStaticDefaults");
+				throw new InvalidOperationException("Tried to register a clicker weapon at the wrong time, do so in ModItem.SetStaticDefaults");
 			}
 			RegisterClickerItem(modItem);
 			int type = modItem.item.type;

--- a/ClickerSystem.cs
+++ b/ClickerSystem.cs
@@ -121,9 +121,10 @@ namespace ClickerClass
 			{
 				throw new UsageException("Tried to register a click effect at the wrong time, do so in Mod.PostSetupContent or ModItem.SetStaticDefaults");
 			}
-			ClickEffect effect = new ClickEffect(internalName, displayName, description, amount, color, action);
-
 			string name = EffectName(mod, internalName);
+
+			ClickEffect effect = new ClickEffect(name, displayName, description, amount, color, action);
+
 			if (!IsClickEffect(name, out _))
 			{
 				ClickEffectsByName.Add(name, effect);

--- a/ClickerSystem.cs
+++ b/ClickerSystem.cs
@@ -17,6 +17,8 @@ namespace ClickerClass
 	{
 		private static HashSet<int> ClickerItems { get; set; }
 
+		private static Dictionary<int, string> ClickerWeaponBorderTexture { get; set; }
+
 		private static HashSet<int> ClickerWeapons { get; set; }
 
 		private static HashSet<int> ClickerProjectiles { get; set; }
@@ -29,6 +31,7 @@ namespace ClickerClass
 		internal static void Load()
 		{
 			ClickerItems = new HashSet<int>();
+			ClickerWeaponBorderTexture = new Dictionary<int, string>();
 			ClickerWeapons = new HashSet<int>();
 			ClickerProjectiles = new HashSet<int>();
 			ClickEffectsByName = new Dictionary<string, ClickEffect>();
@@ -37,6 +40,8 @@ namespace ClickerClass
 		internal static void Unload()
 		{
 			ClickerItems = null;
+			ClickerWeaponBorderTexture?.Clear();
+			ClickerWeaponBorderTexture = null;
 			ClickerWeapons = null;
 			ClickerProjectiles = null;
 			ClickEffectsByName?.Clear();
@@ -215,8 +220,9 @@ namespace ClickerClass
 		/// Do not call <see cref="RegisterClickerItem"/> with it as this method does this already by itself
 		/// </summary>
 		/// <param name="modItem">The <see cref="ModItem"/> that is to be registered</param>
+		/// <param name="borderTexture">The path to the border texture (optional)</param>
 		/// <exception cref="InvalidOperationException"/>
-		public static void RegisterClickerWeapon(ModItem modItem)
+		public static void RegisterClickerWeapon(ModItem modItem, string borderTexture = null)
 		{
 			if (ClickerClass.finalizedRegisterCompat)
 			{
@@ -227,8 +233,37 @@ namespace ClickerClass
 			if (!ClickerWeapons.Contains(type))
 			{
 				ClickerWeapons.Add(type);
+				if (!string.IsNullOrEmpty(borderTexture))
+				{
+					try
+					{
+						var probe = ModContent.GetTexture(borderTexture);
+						if (!ClickerWeaponBorderTexture.ContainsKey(type))
+						{
+							ClickerWeaponBorderTexture.Add(type, borderTexture);
+						}
+					}
+					catch
+					{
+
+					}
+				}
 			}
 			modItem.Tooltip.SetDefault("Click on an enemy within range and sight to damage them");
+		}
+
+		/// <summary>
+		/// Returns the border texture of the item of this type
+		/// </summary>
+		/// <param name="type">The item type</param>
+		/// <returns>The path to the border texture, null if not found</returns>
+		public static string GetPathToBorderTexture(int type)
+		{
+			if (ClickerWeaponBorderTexture.TryGetValue(type, out string borderTexture))
+			{
+				return borderTexture;
+			}
+			return null;
 		}
 
 		/// <summary>

--- a/ClickerSystem.cs
+++ b/ClickerSystem.cs
@@ -2,6 +2,7 @@
 using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
@@ -66,7 +67,7 @@ namespace ClickerClass
 		/// <summary>
 		/// Mod Compat way of accessing an effect's stats. <see cref="null"/> if not found
 		/// </summary>
-		/// <param name="name"></param>
+		/// <param name="name">The unique name</param>
 		/// <returns>Dictionary[string, object]</returns>
 		internal static Dictionary<string, object> GetClickEffectAsDict(string name)
 		{
@@ -105,10 +106,24 @@ namespace ClickerClass
 		}
 
 		/// <summary>
+		/// Mod Compat way of getting obsolete effect names. Can return null if not found
+		/// </summary>
+		/// <param name="oldName">The old display name</param>
+		/// <param name="internalName">The associated internal name</param>
+		/// <returns><see langword="true"/> if exists</returns>
+		internal static bool GetNewNameFromOldDisplayName(string oldName, out string internalName)
+		{
+			var allEffects = GetAllEffects();
+			var found = allEffects.FirstOrDefault(e => e.Value.DisplayName == oldName);
+			internalName = found.Key;
+			return internalName != null;
+		}
+
+		/// <summary>
 		/// Call this in <see cref="Mod.PostSetupContent"/> or <see cref="ModItem.SetStaticDefaults"/> to register this click effect
 		/// </summary>
 		/// <param name="mod">The mod this effect belongs to. ONLY USE YOUR OWN MOD INSTANCE FOR THIS!</param>
-		/// <param name="internalName">The internal name of the effect</param>
+		/// <param name="internalName">The internal name of the effect. Turns into the unique name combined with the associated mod</param>
 		/// <param name="displayName">The name of the effect</param>
 		/// <param name="description">The basic description of the effect, string.Empty for none</param>
 		/// <param name="amount">The amount of clicks required to trigger the effect</param>
@@ -121,6 +136,11 @@ namespace ClickerClass
 			{
 				throw new InvalidOperationException("Tried to register a click effect at the wrong time, do so in Mod.PostSetupContent or ModItem.SetStaticDefaults");
 			}
+			if (string.IsNullOrEmpty(internalName))
+			{
+				throw new InvalidOperationException($"internalName is either null or empty. Give it a proper value");
+			}
+
 			string name = EffectName(mod, internalName);
 
 			ClickEffect effect = new ClickEffect(name, displayName, description, amount, color, action);

--- a/Effects/ShaderManager.cs
+++ b/Effects/ShaderManager.cs
@@ -67,7 +67,7 @@ namespace ClickerClass.Effects
 				{
 					float glow = modPlayer.GlowVisual ? 0.6f : 0f;
 
-					Color outer = modPlayer.clickerColor * (0.2f + glow);
+					Color outer = modPlayer.clickerRadiusColor * (0.2f + glow);
 
 
 					Vector2 center = new Vector2((int)drawPlayer.Center.X, (int)drawPlayer.Center.Y + drawPlayer.gfxOffY);

--- a/Items/Accessories/ChocolateChip.cs
+++ b/Items/Accessories/ChocolateChip.cs
@@ -1,4 +1,8 @@
-﻿using Terraria;
+﻿using ClickerClass.Projectiles;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Accessories
 {
@@ -8,6 +12,21 @@ namespace ClickerClass.Items.Accessories
 		{
 			base.SetStaticDefaults();
 			Tooltip.SetDefault("Every 15 clicks releases a burst of damaging chocolate");
+
+			ClickEffect.ChocolateChip = ClickerSystem.RegisterClickEffect(mod, "ChocolateChip", "Chocolate Chip", "Releases a burst of damaging chocolate", 15, Color.Brown, delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 112);
+				for (int k = 0; k < 6; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-10f, 10f), Main.rand.NextFloat(-10f, 10f), ModContent.ProjectileType<ChocolateChipPro>(), (int)(damage * 0.2), 0f, player.whoAmI, Main.rand.Next(3), 0f);
+				}
+				for (int k = 0; k < 20; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 22, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 125, default, 1.5f);
+					dust.noGravity = true;
+					dust.noLight = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -21,7 +40,7 @@ namespace ClickerClass.Items.Accessories
 
 		public override void UpdateAccessory(Player player, bool hideVisual)
 		{
-			player.GetModPlayer<ClickerPlayer>().accChocolateChip = true;
+			player.GetModPlayer<ClickerPlayer>().EnableClickEffect(ClickEffect.ChocolateChip);
 		}
 	}
 }

--- a/Items/Accessories/ChocolateMilkCookies.cs
+++ b/Items/Accessories/ChocolateMilkCookies.cs
@@ -28,7 +28,7 @@ namespace ClickerClass.Items.Accessories
 		public override void UpdateAccessory(Player player, bool hideVisual)
 		{
 			ClickerPlayer clickerPlayer = player.GetModPlayer<ClickerPlayer>();
-			clickerPlayer.accChocolateChip = true;
+			clickerPlayer.EnableClickEffect(ClickEffect.ChocolateChip);
 			clickerPlayer.accCookie2 = true;
 			clickerPlayer.accGlassOfMilk = true;
 		}

--- a/Items/Accessories/StickyKeychain.cs
+++ b/Items/Accessories/StickyKeychain.cs
@@ -12,7 +12,7 @@ namespace ClickerClass.Items.Accessories
 			base.SetStaticDefaults();
 			Tooltip.SetDefault("Every 10 clicks sticks damaging slime on to your screen");
 
-			ClickEffect.StickyKeychain = ClickerSystem.RegisterClickEffect(mod, "StickyKeychain", "Sticky Keychain", "Every 10 clicks sticks damaging slime on to your screen", 10, Color.White, delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			ClickEffect.StickyKeychain = ClickerSystem.RegisterClickEffect(mod, "StickyKeychain", "Sticky Keychain", "Sticks damaging slime on to your screen", 10, Color.White, delegate (Player player, Vector2 position, int type, int damage, float knockBack)
 			{
 				Main.PlaySound(3, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 13);
 				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<StickyKeychainPro>(), (int)(damage * 0.5), 3f, player.whoAmI, Main.rand.Next(3));

--- a/Items/Accessories/StickyKeychain.cs
+++ b/Items/Accessories/StickyKeychain.cs
@@ -1,4 +1,7 @@
-﻿using Terraria;
+﻿using ClickerClass.Projectiles;
+using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Accessories
 {
@@ -8,6 +11,18 @@ namespace ClickerClass.Items.Accessories
 		{
 			base.SetStaticDefaults();
 			Tooltip.SetDefault("Every 10 clicks sticks damaging slime on to your screen");
+
+			ClickEffect.StickyKeychain = ClickerSystem.RegisterClickEffect(mod, "StickyKeychain", "Sticky Keychain", "Every 10 clicks sticks damaging slime on to your screen", 10, Color.White, delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(3, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 13);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<StickyKeychainPro>(), (int)(damage * 0.5), 3f, player.whoAmI, Main.rand.Next(3));
+				for (int k = 0; k < 20; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 88, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 175, default, 1.75f);
+					dust.noGravity = true;
+					dust.noLight = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -21,7 +36,7 @@ namespace ClickerClass.Items.Accessories
 
 		public override void UpdateAccessory(Player player, bool hideVisual)
 		{
-			player.GetModPlayer<ClickerPlayer>().accStickyKeychain = true;
+			player.GetModPlayer<ClickerPlayer>().EnableClickEffect(ClickEffect.StickyKeychain);
 		}
 	}
 }

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -5,6 +5,7 @@ using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
 using System.Collections.Generic;
 using Terraria;
+using Terraria.GameInput;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.Utilities;
@@ -243,11 +244,28 @@ namespace ClickerClass.Items
 
 						if (index != -1)
 						{
-							foreach (var name in effects)
+							//"Auto Select" key: player.controlTorch
+							var keys = PlayerInput.CurrentProfile.InputModes[InputMode.Keyboard].KeyStatus[TriggerNames.SmartSelect];
+							string key = keys.Count == 0 ? null : keys[0];
+
+							//If has a key, but not pressing it, show the ForMoreInfo text
+							//Otherwise, list all effects
+
+							if (key != null && !player.controlTorch)
 							{
-								if (ClickerSystem.IsClickEffect(name, out ClickEffect effect))
+								tooltips.Insert(++index, new TooltipLine(mod, "ForMoreInfo", $"Hold 'Auto Select' key ({key}) to show click effects")
 								{
-									tooltips.Insert(++index, effect.ToTooltip(clickerPlayer.GetClickAmountTotal(this, name), alpha));
+									overrideColor = Color.LightGray
+								});
+							}
+							else
+							{
+								foreach (var name in effects)
+								{
+									if (ClickerSystem.IsClickEffect(name, out ClickEffect effect))
+									{
+										tooltips.Insert(++index, effect.ToTooltip(clickerPlayer.GetClickAmountTotal(this, name), alpha));
+									}
 								}
 							}
 						}

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -228,11 +228,14 @@ namespace ClickerClass.Items
 					}
 
 					//Show the clicker's effects
-					//Then show ones missing through the players enabled effects (respecting overlap)
+					//Then show ones missing through the players enabled effects (respecting overlap, ignoring the currently held clickers effect if its not the same type)
 					List<string> effects = new List<string>(itemClickEffects);
 					foreach (var name in ClickerSystem.GetAllEffectNames())
 					{
-						if (clickerPlayer.HasClickEffect(name, out ClickEffect effect) && !effects.Contains(name))
+						var heldItemEffects = player.HeldItem.GetGlobalItem<ClickerItemCore>().itemClickEffects;
+						if (clickerPlayer.HasClickEffect(name, out ClickEffect effect) &&
+							!effects.Contains(name) &&
+							player.HeldItem.type == item.type && !heldItemEffects.Contains(name))
 						{
 							effects.Add(name);
 						}

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -234,8 +234,7 @@ namespace ClickerClass.Items
 					{
 						if (clickerPlayer.HasClickEffect(name, out ClickEffect effect) && !effects.Contains(name))
 						{
-							var heldItemEffects = player.HeldItem.GetGlobalItem<ClickerItemCore>().itemClickEffects;
-							if (!(player.HeldItem.type != item.type && heldItemEffects.Contains(name)))
+							if (!(player.HeldItem.type != item.type && player.HeldItem.type != ItemID.None && player.HeldItem.GetGlobalItem<ClickerItemCore>().itemClickEffects.Contains(name)))
 							{
 								effects.Add(name);
 							}

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -21,7 +21,7 @@ namespace ClickerClass.Items
 		/// <summary>
 		/// A clickers color used for the radius
 		/// </summary>
-		public Color clickerColorItem = Color.White;
+		public Color clickerRadiusColor = Color.White;
 
 		/// <summary>
 		/// The clickers effects
@@ -49,7 +49,7 @@ namespace ClickerClass.Items
 		public override GlobalItem Clone(Item item, Item itemClone)
 		{
 			ClickerItemCore myClone = (ClickerItemCore)base.Clone(item, itemClone);
-			myClone.clickerColorItem = clickerColorItem;
+			myClone.clickerRadiusColor = clickerRadiusColor;
 			myClone.itemClickEffects = new List<string>(itemClickEffects);
 			myClone.clickerDustColor = clickerDustColor;
 			myClone.clickBoostPrefix = clickBoostPrefix;

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -245,6 +245,7 @@ namespace ClickerClass.Items
 						if (index != -1)
 						{
 							//"Auto Select" key: player.controlTorch
+
 							var keys = PlayerInput.CurrentProfile.InputModes[InputMode.Keyboard].KeyStatus[TriggerNames.SmartSelect];
 							string key = keys.Count == 0 ? null : keys[0];
 
@@ -263,10 +264,21 @@ namespace ClickerClass.Items
 
 							if (!showDesc)
 							{
-								tooltips.Insert(++index, new TooltipLine(mod, "ForMoreInfo", $"Hold 'Auto Select' key ({key}) to show click effects")
+								//Add ForMoreInfo as the last line
+								index = tooltips.FindLastIndex(tt => tt.mod.Equals("Terraria") && tt.Name.StartsWith("Tooltip"));
+								var ttl = new TooltipLine(mod, "ForMoreInfo", $"Hold 'Auto Select' key ({key}) to show click effects")
 								{
 									overrideColor = Color.Gray
-								});
+								};
+
+								if (index != -1)
+								{
+									tooltips.Insert(++index, ttl);
+								}
+								else
+								{
+									tooltips.Add(ttl);
+								}
 							}
 						}
 					}

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -251,22 +251,22 @@ namespace ClickerClass.Items
 							//If has a key, but not pressing it, show the ForMoreInfo text
 							//Otherwise, list all effects
 
-							if (key != null && !player.controlTorch)
+							bool showDesc = key == null || player.controlTorch;
+
+							foreach (var name in effects)
+							{
+								if (ClickerSystem.IsClickEffect(name, out ClickEffect effect))
+								{
+									tooltips.Insert(++index, effect.ToTooltip(clickerPlayer.GetClickAmountTotal(this, name), alpha, showDesc));
+								}
+							}
+
+							if (key != null)
 							{
 								tooltips.Insert(++index, new TooltipLine(mod, "ForMoreInfo", $"Hold 'Auto Select' key ({key}) to show click effects")
 								{
-									overrideColor = Color.LightGray
+									overrideColor = Color.Gray
 								});
-							}
-							else
-							{
-								foreach (var name in effects)
-								{
-									if (ClickerSystem.IsClickEffect(name, out ClickEffect effect))
-									{
-										tooltips.Insert(++index, effect.ToTooltip(clickerPlayer.GetClickAmountTotal(this, name), alpha));
-									}
-								}
 							}
 						}
 					}

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -372,9 +372,7 @@ namespace ClickerClass.Items
 				Main.PlaySound(SoundID.MenuTick, player.position);
 				if (!player.HasBuff(ModContent.BuffType<AutoClick>()))
 				{
-					clickerPlayer.clickerPerSecond++;
-					clickerPlayer.clickAmount++;
-					clickerPlayer.clickerTotal++;
+					clickerPlayer.Click();
 				}
 
 				//TODO "PreShoot" hook wrapping around the next NewProjectile

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -3,7 +3,6 @@ using ClickerClass.Dusts;
 using ClickerClass.Prefixes;
 using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
-using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
@@ -20,27 +19,20 @@ namespace ClickerClass.Items
 		public override bool InstancePerEntity => true;
 
 		/// <summary>
-		/// A clickers color used for various things
+		/// A clickers color used for the radius
 		/// </summary>
 		public Color clickerColorItem = Color.White;
 
 		/// <summary>
-		/// The amount of clicks required for an effect to trigger
+		/// The clickers effects
 		/// </summary>
-		public int itemClickerAmount = 0;
-
-		public const string NULL = "NULL";
-
-		/// <summary>
-		/// The clickers effect name
-		/// </summary>
-		public string itemClickerEffect = NULL;
+		public List<string> itemClickEffects = new List<string>();
 
 		/// <summary>
 		/// The clickers dust that is spawned on use
 		/// </summary>
 		public int clickerDustColor = 0;
-		
+
 		/// <summary>
 		/// Displays total clicks in the tooltip
 		/// </summary>
@@ -58,8 +50,7 @@ namespace ClickerClass.Items
 		{
 			ClickerItemCore myClone = (ClickerItemCore)base.Clone(item, itemClone);
 			myClone.clickerColorItem = clickerColorItem;
-			myClone.itemClickerAmount = itemClickerAmount;
-			myClone.itemClickerEffect = itemClickerEffect;
+			myClone.itemClickEffects = new List<string>(itemClickEffects);
 			myClone.clickerDustColor = clickerDustColor;
 			myClone.clickBoostPrefix = clickBoostPrefix;
 			myClone.isClickerDisplayTotal = isClickerDisplayTotal;
@@ -130,7 +121,7 @@ namespace ClickerClass.Items
 					item.autoReuse = false;
 				}
 
-				if (!itemClickerEffect.Contains("Phase Reach"))
+				if (!clickerPlayer.HasClickEffect(ClickEffect.PhaseReach))
 				{
 					//collision
 					Vector2 motherboardPosition = clickerPlayer.setMotherboardPosition;
@@ -193,7 +184,7 @@ namespace ClickerClass.Items
 				Player player = Main.LocalPlayer;
 				var clickerPlayer = player.GetModPlayer<ClickerPlayer>();
 				int index;
-				
+
 				float alpha = Main.mouseTextColor / 255f;
 
 				if (ClickerConfigClient.Instance.ShowClassTags)
@@ -203,7 +194,7 @@ namespace ClickerClass.Items
 					{
 						tooltips.Insert(index + 1, new TooltipLine(mod, "ClickerTag", "-Clicker Class-")
 						{
-							overrideColor = new Color(Main.DiscoR, Main.DiscoG, Main.DiscoB)
+							overrideColor = Main.DiscoColor
 						});
 					}
 				}
@@ -215,44 +206,49 @@ namespace ClickerClass.Items
 					if (index != -1)
 					{
 						string color = (new Color(252, 210, 44) * alpha).Hex3();
-						tooltips.Add(new TooltipLine(mod, "transformationText", "Total clicks: " + $"[c/" + color + ":" + clickerPlayer.clickerTotal + "]"));
+						tooltips.Add(new TooltipLine(mod, "TransformationText", $"Total clicks: [c/{color}:{clickerPlayer.clickerTotal}]"));
 					}
 				}
 
 				if (ClickerSystem.IsClickerWeapon(item))
 				{
-					if (!itemClickerEffect.Contains("The Click"))
+					TooltipLine tooltip = tooltips.Find(tt => tt.mod.Equals("Terraria") && tt.Name.Equals("Damage"));
+					if (tooltip != null)
 					{
-						TooltipLine tooltip = tooltips.Find(tt => tt.mod.Equals("Terraria") && tt.Name.Equals("Damage"));
-						if (tooltip != null)
+						string number = tooltip.text.Split(' ')[0];
+						if (!clickerPlayer.HasClickEffect(ClickEffect.TheClick))
 						{
-							tooltip.text = tooltip.text.Split(' ')[0] + " click damage";
+							tooltip.text = $"{number} click damage";
 						}
-					}
-					else
-					{
-						TooltipLine tooltip = tooltips.Find(tt => tt.mod.Equals("Terraria") && tt.Name.Equals("Damage"));
-						if (tooltip != null)
+						else
 						{
-							tooltip.text = tooltip.text.Split(' ')[0] + " + 1% enemy life click damage";
+							tooltip.text = $"{number} + 1% enemy life click damage";
 						}
 					}
 
-					if (itemClickerAmount > 0 && itemClickerEffect != NULL)
+					//Show the clicker's effects
+					//Then show ones missing through the players enabled effects (respecting overlap)
+					List<string> effects = new List<string>(itemClickEffects);
+					foreach (var name in ClickerSystem.GetAllEffectNames())
+					{
+						if (clickerPlayer.HasClickEffect(name, out ClickEffect effect) && !effects.Contains(name))
+						{
+							effects.Add(name);
+						}
+					}
+
+					if (effects.Count > 0)
 					{
 						index = tooltips.FindIndex(tt => tt.mod.Equals("Terraria") && tt.Name.Equals("Knockback"));
 
 						if (index != -1)
 						{
-							string color = (clickerColorItem * alpha).Hex3();
-							int clickAmountTotal = clickerPlayer.GetClickAmountTotal(this);
-							if (clickAmountTotal > 1)
+							foreach (var name in effects)
 							{
-								tooltips.Insert(index + 1, new TooltipLine(mod, "itemClickerAmount", clickAmountTotal + " clicks - " + $"[c/" + color + ":" + itemClickerEffect + "]"));
-							}
-							else
-							{
-								tooltips.Insert(index + 1, new TooltipLine(mod, "itemClickerAmount", "1 click - " + $"[c/" + color + ":" + itemClickerEffect + "]"));
+								if (ClickerSystem.IsClickEffect(name, out ClickEffect effect))
+								{
+									tooltips.Insert(++index, effect.ToTooltip(clickerPlayer.GetClickAmountTotal(this, name), alpha));
+								}
 							}
 						}
 					}
@@ -263,31 +259,26 @@ namespace ClickerClass.Items
 					return;
 				}
 
-				if (radiusBoostPrefix != 0)
+				int ttindex = tooltips.FindLastIndex(t => (t.mod == "Terraria" || t.mod == mod.Name) && (t.isModifier || t.Name.StartsWith("Tooltip") || t.Name.Equals("Material")));
+				if (ttindex != -1)
 				{
-					int ttindex = tooltips.FindLastIndex(t => (t.mod == "Terraria" || t.mod == mod.Name) && (t.isModifier || t.Name.StartsWith("Tooltip") || t.Name.Equals("Material")));
-					if (ttindex != -1)
+					if (radiusBoostPrefix != 0)
 					{
 						TooltipLine tt = new TooltipLine(mod, "PrefixClickerRadius", (radiusBoostPrefix > 0 ? "+" : "") + (int)((radiusBoostPrefix / 2) * 100) + "% base clicker radius")
 						{
 							isModifier = true,
 							isModifierBad = radiusBoostPrefix < 0
 						};
-						tooltips.Insert(ttindex + 1, tt);
+						tooltips.Insert(++ttindex, tt);
 					}
-				}
-
-				if (clickBoostPrefix != 0)
-				{
-					int ttindex = tooltips.FindLastIndex(t => (t.mod == "Terraria" || t.mod == mod.Name) && (t.isModifier || t.Name.StartsWith("Tooltip") || t.Name.Equals("Material")));
-					if (ttindex != -1)
+					if (radiusBoostPrefix != 0)
 					{
 						TooltipLine tt = new TooltipLine(mod, "PrefixClickBoost", (clickBoostPrefix < 0 ? "" : "+") + clickBoostPrefix + " clicks required")
 						{
 							isModifier = true,
 							isModifierBad = clickBoostPrefix > 0
 						};
-						tooltips.Insert(ttindex + 1, tt);
+						tooltips.Insert(++ttindex, tt);
 					}
 				}
 			}
@@ -329,7 +320,7 @@ namespace ClickerClass.Items
 						if (clickerPlayer.setMice)
 						{
 							bool canTeleport = false;
-							if (!itemClickerEffect.Contains("Phase Reach"))
+							if (!clickerPlayer.HasClickEffect(ClickEffect.PhaseReach))
 							{
 								//collision
 								if (Vector2.Distance(Main.MouseWorld, player.Center) < clickerPlayer.ClickerRadiusReal && Collision.CanHitLine(new Vector2(player.Center.X, player.Center.Y - 12), 1, 1, Main.MouseWorld, 1, 1))
@@ -344,7 +335,7 @@ namespace ClickerClass.Items
 
 							if (canTeleport)
 							{
-								Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 115);
+								Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 115);
 								Main.SetCameraLerp(0.1f, 0);
 								player.Center = Main.MouseWorld;
 								NetMessage.SendData(MessageID.PlayerControls, number: player.whoAmI);
@@ -397,9 +388,6 @@ namespace ClickerClass.Items
 					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<PrecursorPro>(), (int)(damage * 0.25f), knockBack, player.whoAmI);
 				}
 
-				//Find click amount
-				int clickAmountTotal = clickerPlayer.GetClickAmountTotal(this);
-
 				//Overclock armor set bonus
 				if (clickerPlayer.clickAmount % 100 == 0 && clickerPlayer.setOverclock)
 				{
@@ -421,515 +409,24 @@ namespace ClickerClass.Items
 					}
 				}
 
-				//Special Effects
-				if (clickerPlayer.clickAmount % 10 == 0 && clickerPlayer.accStickyKeychain)
+				bool autoClick = player.HasBuff(ModContent.BuffType<AutoClick>());
+				bool overclock = player.HasBuff(ModContent.BuffType<OverclockBuff>());
+
+				foreach (var name in ClickerSystem.GetAllEffectNames())
 				{
-					Main.PlaySound(3, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 13);
-					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<StickyKeychainPro>(), (int)(damage * 0.5), 3f, player.whoAmI, Main.rand.Next(3));
-					for (int k = 0; k < 20; k++)
+					if (clickerPlayer.HasClickEffect(name, out ClickEffect effect))
 					{
-						Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 88, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 175, default, 1.75f);
-						dust.noGravity = true;
-						dust.noLight = true;
-					}
-				}
-				if (clickerPlayer.clickAmount % 15 == 0 && clickerPlayer.accChocolateChip)
-				{
-					Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 112);
-					for (int k = 0; k < 6; k++)
-					{
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-10f, 10f), Main.rand.NextFloat(-10f, 10f), ModContent.ProjectileType<ChocolateChipPro>(), (int)(damage * 0.2), 0f, player.whoAmI, Main.rand.Next(3), 0f);
-					}
-					for (int k = 0; k < 20; k++)
-					{
-						Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 22, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 125, default, 1.5f);
-						dust.noGravity = true;
-						dust.noLight = true;
+						//Find click amount
+						int clickAmountTotal = clickerPlayer.GetClickAmountTotal(this, name);
+						bool reachedAmount = clickerPlayer.clickAmount % clickAmountTotal == 0;
+
+						if (!autoClick && (reachedAmount || overclock))
+						{
+							effect.Action?.Invoke(player, position, type, damage, knockBack);
+						}
 					}
 				}
 
-				//Clicker Effects
-				if ((clickerPlayer.clickAmount % clickAmountTotal == 0 || player.HasBuff(ModContent.BuffType<OverclockBuff>())) && !player.HasBuff(ModContent.BuffType<AutoClick>()))
-				{
-					// Pumpkin Moon Clicker Effect
-					int wildMagic = 0;
-					if (itemClickerEffect.Contains("Wild Magic"))
-					{
-						wildMagic = 1 + Main.rand.Next(28);
-					}
-
-					// Metal Double Click Effect
-					if (itemClickerEffect.Contains("Double Click") || wildMagic == 1)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 37);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, type, damage, knockBack, player.whoAmI);
-					}
-
-					// Candle Clicker Effect
-					if (itemClickerEffect.Contains("Illuminate") || wildMagic == 26)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 74);
-						for (int k = 0; k < 15; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 55, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 255, default, 1.35f);
-							dust.noGravity = true;
-						}
-						for (int k = 0; k < 8; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-5f, 5f), Main.rand.NextFloat(-5f, 5f), ModContent.ProjectileType<CandleClickerPro>(), 0, 0f, player.whoAmI);
-						}
-					}
-
-					// Hemo Clicker Effect
-					if (itemClickerEffect.Contains("Linger") || wildMagic == 2)
-					{
-						Main.PlaySound(3, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 13);
-						for (int k = 0; k < 5; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-3f, -1f), ModContent.ProjectileType<HemoClickerPro>(), (int)(damage * 0.50f), 0f, player.whoAmI);
-						}
-					}
-
-					// Bone Clicker Effect
-					if (itemClickerEffect.Contains("Lacerate") || wildMagic == 3)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 71);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<BoneClickerPro>(), damage, knockBack, player.whoAmI);
-						for (int k = 0; k < 10; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 5, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 125, default, 1.25f);
-							dust.noGravity = true;
-						}
-					}
-
-					// Corruption Clicker Effect
-					if (itemClickerEffect.Contains("Dark Burst") || wildMagic == 4)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 70);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<DarkClickerPro>(), damage, knockBack, player.whoAmI);
-						for (int k = 0; k < 25; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 14, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 75, default, 1.5f);
-							dust.noGravity = true;
-						}
-					}
-
-					// Crimson Clicker Effect
-					if (itemClickerEffect.Contains("Siphon") || wildMagic == 5)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 112);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<SinisterClickerPro>(), (int)(damage * 0.50f), knockBack, player.whoAmI);
-						for (int i = 0; i < 15; i++)
-						{
-							int num6 = Dust.NewDust(Main.MouseWorld, 20, 20, 5, 0f, 0f, 75, default(Color), 1.5f);
-							Main.dust[num6].noGravity = true;
-							Main.dust[num6].velocity *= 0.75f;
-							int num7 = Main.rand.Next(-50, 51);
-							int num8 = Main.rand.Next(-50, 51);
-							Dust dust = Main.dust[num6];
-							dust.position.X = dust.position.X + (float)num7;
-							Dust dust2 = Main.dust[num6];
-							dust2.position.Y = dust2.position.Y + (float)num8;
-							Main.dust[num6].velocity.X = -(float)num7 * 0.075f;
-							Main.dust[num6].velocity.Y = -(float)num8 * 0.075f;
-						}
-					}
-
-					// Meteor Clicker Effect
-					if (itemClickerEffect.Contains("Star Storm") || wildMagic == 6)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 42);
-
-						for (int k = 0; k < 3; k++)
-						{
-							Vector2 startSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-100, 101), Main.MouseWorld.Y - 500 + Main.rand.Next(-25, 26));
-							Vector2 endSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-25, 26), Main.MouseWorld.Y + Main.rand.Next(-25, 26));
-							Vector2 vector = endSpot - startSpot;
-							float speed = 5f;
-							float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
-							if (mag > speed)
-							{
-								mag = speed / mag;
-							}
-							vector *= mag;
-							Projectile.NewProjectile(startSpot.X, startSpot.Y, vector.X, vector.Y, ModContent.ProjectileType<SpaceClickerPro>(), (int)(damage * 0.75f), knockBack, player.whoAmI, endSpot.X, endSpot.Y);
-						}
-					}
-
-					// Shadowy Clicker Effect
-					if (itemClickerEffect.Contains("Curse") || wildMagic == 27)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 104);
-						for (int k = 0; k < 15; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 27, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 255, default, 1f);
-							dust.noGravity = true;
-						}
-
-						int index = -1;
-						for (int i = 0; i < 200; i++)
-						{
-							NPC npc = Main.npc[i];
-							if (npc.active && Vector2.Distance(Main.MouseWorld, npc.Center) < 400f && Collision.CanHit(Main.MouseWorld, 1, 1, npc.Center, 1, 1))
-							{
-								index = i;
-							}
-						}
-						if (index != -1)
-						{
-							Vector2 vector = Main.npc[index].Center - Main.MouseWorld;
-							float speed = 6f;
-							float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
-							if (mag > speed)
-							{
-								mag = speed / mag;
-							}
-							vector *= mag;
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, vector.X, vector.Y, ModContent.ProjectileType<ShadowyClickerPro>(), damage, knockBack, player.whoAmI);
-						}
-					}
-
-					// Dungeon Clicker Effect
-					if (itemClickerEffect.Contains("Splash") || wildMagic == 7)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 86);
-						for (int k = 0; k < 6; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-6f, -2f), ModContent.ProjectileType<SlickClickerPro>(), (int)(damage * 0.75f), knockBack, player.whoAmI);
-						}
-					}
-
-					// Jungle Clicker Effect
-					if (itemClickerEffect.Contains("Stinging Thorn") || wildMagic == 8)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 17);
-
-						int index = -1;
-						for (int i = 0; i < 200; i++)
-						{
-							NPC npc = Main.npc[i];
-							if (npc.active && Vector2.Distance(Main.MouseWorld, npc.Center) < 400f && Collision.CanHit(Main.MouseWorld, 1, 1, npc.Center, 1, 1))
-							{
-								index = i;
-							}
-						}
-						if (index != -1)
-						{
-							Vector2 vector = Main.npc[index].Center - Main.MouseWorld;
-							float speed = 3f;
-							float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
-							if (mag > speed)
-							{
-								mag = speed / mag;
-							}
-							vector *= mag;
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, vector.X, vector.Y, ModContent.ProjectileType<PointyClickerPro>(), damage, knockBack, player.whoAmI);
-						}
-					}
-
-					// Molten Clicker Effect
-					if (itemClickerEffect.Contains("Inferno") || wildMagic == 9)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 74);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<RedHotClickerPro>(), 0, knockBack, player.whoAmI);
-					}
-
-					// Night Clicker Effect
-					if (itemClickerEffect.Contains("Shadow Lash") || wildMagic == 10)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 103);
-						for (int k = 0; k < 5; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-3f, 3f), Main.rand.NextFloat(-3f, 3f), ModContent.ProjectileType<UmbralClickerPro>(), (int)(damage * 0.5f), knockBack, player.whoAmI);
-						}
-					}
-
-					// Cobalt Clicker Effect
-					if (itemClickerEffect.Contains("Haste") || wildMagic == 11)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
-						player.AddBuff(ModContent.BuffType<Haste>(), 300, false);
-						for (int i = 0; i < 15; i++)
-						{
-							int num6 = Dust.NewDust(player.position, 20, 20, 56, 0f, 0f, 150, default(Color), 1.25f);
-							Main.dust[num6].noGravity = true;
-							Main.dust[num6].velocity *= 0.75f;
-							int num7 = Main.rand.Next(-50, 51);
-							int num8 = Main.rand.Next(-50, 51);
-							Dust dust = Main.dust[num6];
-							dust.position.X = dust.position.X + (float)num7;
-							Dust dust2 = Main.dust[num6];
-							dust2.position.Y = dust2.position.Y + (float)num8;
-							Main.dust[num6].velocity.X = -(float)num7 * 0.075f;
-							Main.dust[num6].velocity.Y = -(float)num8 * 0.075f;
-						}
-					}
-
-					// Palladium Clicker Effect
-					if (itemClickerEffect.Contains("Regenerate") || wildMagic == 12)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
-						player.AddBuff(BuffID.RapidHealing, 120, false);
-						for (int i = 0; i < 15; i++)
-						{
-							int num6 = Dust.NewDust(player.position, 20, 20, ModContent.DustType<LoveDust>(), 0f, 0f, 0, Color.White, 1f);
-							Main.dust[num6].noGravity = true;
-							Main.dust[num6].velocity *= 0.75f;
-							int num7 = Main.rand.Next(-50, 51);
-							int num8 = Main.rand.Next(-50, 51);
-							Dust dust = Main.dust[num6];
-							dust.position.X = dust.position.X + (float)num7;
-							Dust dust2 = Main.dust[num6];
-							dust2.position.Y = dust2.position.Y + (float)num8;
-							Main.dust[num6].velocity.X = -(float)num7 * 0.075f;
-							Main.dust[num6].velocity.Y = -(float)num8 * 0.075f;
-						}
-					}
-
-					// Mythril Clicker Effect
-					if (itemClickerEffect.Contains("Embrittle") || wildMagic == 13)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 101);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<MythrilClickerPro>(), 0, knockBack, player.whoAmI);
-					}
-
-					// Orich Clicker Effect
-					if (itemClickerEffect.Contains("Petal Storm") || wildMagic == 14)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
-
-						for (int k = 0; k < 5; k++)
-						{
-							float xChoice = Main.rand.Next(-100, 101);
-							float yChoice = Main.rand.Next(-100, 101);
-							xChoice += xChoice > 0 ? 300 : -300;
-							yChoice += yChoice > 0 ? 300 : -300;
-							Vector2 startSpot = new Vector2(Main.MouseWorld.X + xChoice, Main.MouseWorld.Y + yChoice);
-							Vector2 endSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-10, 11), Main.MouseWorld.Y + Main.rand.Next(-10, 11));
-							Vector2 vector = endSpot - startSpot;
-							float speed = 4f;
-							float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
-							if (mag > speed)
-							{
-								mag = speed / mag;
-							}
-							vector *= mag;
-							Projectile.NewProjectile(startSpot.X, startSpot.Y, vector.X, vector.Y, ModContent.ProjectileType<OrichaclumClickerPro>(), (int)(damage * 0.5f), 0f, player.whoAmI, Main.rand.Next(3), 0f);
-						}
-					}
-
-					// Adamantite Clicker Effect
-					if (itemClickerEffect.Contains("True Strike") || wildMagic == 15)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 71);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<AdamantiteClickerPro>(), damage, knockBack, player.whoAmI);
-					}
-
-					// Titanium Clicker Effect
-					if (itemClickerEffect.Contains("Razor's Edge") || wildMagic == 16)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 22);
-						for (int k = 0; k < 5; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<TitaniumClickerPro>(), (int)(damage * 0.75f), 0f, player.whoAmI, k, 0f);
-						}
-						for (int k = 0; k < 15; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 91, Main.rand.NextFloat(-3f, 3f), Main.rand.NextFloat(-3f, 3f), 0, default, 1.25f);
-							dust.noGravity = true;
-						}
-					}
-
-					// Crystal Clicker Effect
-					if (itemClickerEffect.Contains("Dazzle") || wildMagic == 17)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 28);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<CrystalClickerPro>(), 0, knockBack, player.whoAmI);
-					}
-
-					// Cursed Clicker Effect
-					if (itemClickerEffect.Contains("Cursed Eruption") || wildMagic == 18)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 74);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<CorruptClickerPro>(), damage, knockBack, player.whoAmI);
-						for (int k = 0; k < 30; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 163, Main.rand.NextFloat(-10f, 10f), Main.rand.NextFloat(-10f, 10f), 0, default, 1.65f);
-							dust.noGravity = true;
-						}
-					}
-
-					// Ichor Clicker Effect
-					if (itemClickerEffect.Contains("Infest") || wildMagic == 19)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
-						for (int k = 0; k < 8; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-3f, 3f), Main.rand.NextFloat(-3f, 3f), ModContent.ProjectileType<CrimsonClickerPro>(), (int)(damage * 0.25f), knockBack, player.whoAmI);
-						}
-					}
-
-					// Pirate Clicker Effect
-					if (itemClickerEffect.Contains("Bombard") || wildMagic == 20)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 14);
-
-						for (int k = 0; k < 4; k++)
-						{
-							Vector2 startSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-150, 151), Main.MouseWorld.Y - 500 + Main.rand.Next(-25, 26));
-							Vector2 endSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-25, 26), Main.MouseWorld.Y + Main.rand.Next(-25, 26));
-							Vector2 vector = endSpot - startSpot;
-							float speed = 8f + Main.rand.NextFloat(-1f, 1f);
-							float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
-							if (mag > speed)
-							{
-								mag = speed / mag;
-							}
-							vector *= mag;
-							Projectile.NewProjectile(startSpot.X, startSpot.Y, vector.X, vector.Y, ModContent.ProjectileType<CaptainsClickerPro>(), damage, knockBack, player.whoAmI, endSpot.X, endSpot.Y);
-						}
-					}
-
-					// Eclipse Clicker Effect
-					if (itemClickerEffect.Contains("Totality") || wildMagic == 28)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 43);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<TotalityClickerPro>(), damage, knockBack, player.whoAmI);
-					}
-
-					// Hallowed Clicker Effect
-					if (itemClickerEffect.Contains("Holy Nova") || wildMagic == 21)
-					{
-						Main.PlaySound(3, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 5);
-						for (int u = 0; u < Main.maxNPCs; u++)
-						{
-							NPC target = Main.npc[u];
-							if (Collision.CanHit(target.Center, 1, 1, Main.MouseWorld, 1, 1) && target.DistanceSQ(Main.MouseWorld) < 350 * 350)
-							{
-								Vector2 vector = target.Center - Main.MouseWorld;
-								float speed = 8f;
-								float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
-								if (mag > speed)
-								{
-									mag = speed / mag;
-								}
-								vector *= mag;
-								Projectile.NewProjectile(target.Center.X, target.Center.Y, 0f, 0f, ModContent.ProjectileType<ArthursClickerPro>(), (int)(damage * 0.75f), knockBack, player.whoAmI, 1f, 0f);
-
-								for (int k = 0; k < 30; k++)
-								{
-									Dust dust = Dust.NewDustDirect(target.Center, 8, 8, 87, vector.X + Main.rand.NextFloat(-1f, 1f), vector.Y + Main.rand.NextFloat(-1f, 1f), 0, default, 1.25f);
-									dust.noGravity = true;
-								}
-							}
-						}
-
-						float num102 = 100f;
-						int num103 = 0;
-						while ((float)num103 < num102)
-						{
-							Vector2 vector12 = Vector2.UnitX * 0f;
-							vector12 += -Vector2.UnitY.RotatedBy((double)((float)num103 * (6.28318548f / num102)), default(Vector2)) * new Vector2(2f, 2f);
-							vector12 = vector12.RotatedBy((double)Vector2.Zero.ToRotation(), default(Vector2));
-							int num104 = Dust.NewDust(Main.MouseWorld, 0, 0, 87, 0f, 0f, 0, default(Color), 2f);
-							Main.dust[num104].noGravity = true;
-							Main.dust[num104].position = Main.MouseWorld + vector12;
-							Main.dust[num104].velocity = Vector2.Zero * 0f + vector12.SafeNormalize(Vector2.UnitY) * 15f;
-							int num = num103;
-							num103 = num + 1;
-						}
-					}
-
-					// Chloro Clicker Effect
-					if (itemClickerEffect.Contains("Toxic Release") || wildMagic == 22)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 104);
-						for (int k = 0; k < 10; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-5f, 5f), Main.rand.NextFloat(-5f, 5f), ModContent.ProjectileType<ChlorophyteClickerPro>(), (int)(damage * 0.5f), 0f, player.whoAmI);
-						}
-					}
-
-					// Shroom Clicker Effect
-					if (itemClickerEffect.Contains("Auto Click") || wildMagic == 23)
-					{
-						clickerPlayer.clickAmount++;
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
-						player.AddBuff(ModContent.BuffType<AutoClick>(), 300, false);
-						for (int i = 0; i < 15; i++)
-						{
-							int num6 = Dust.NewDust(player.position, 20, 20, 15, 0f, 0f, 255, default(Color), 1.5f);
-							Main.dust[num6].noGravity = true;
-							Main.dust[num6].velocity *= 0.75f;
-							int num7 = Main.rand.Next(-50, 51);
-							int num8 = Main.rand.Next(-50, 51);
-							Dust dust = Main.dust[num6];
-							dust.position.X = dust.position.X + (float)num7;
-							Dust dust2 = Main.dust[num6];
-							dust2.position.Y = dust2.position.Y + (float)num8;
-							Main.dust[num6].velocity.X = -(float)num7 * 0.075f;
-							Main.dust[num6].velocity.Y = -(float)num8 * 0.075f;
-						}
-					}
-
-					// Temple Clicker Effect
-					if (itemClickerEffect.Contains("Solar Flare") || wildMagic == 24)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 68);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<LihzarhdClickerPro>(), (int)(damage * 0.5f), 0f, player.whoAmI);
-					}
-
-					// Martian Clicker Effect
-					if (itemClickerEffect.Contains("Discharge") || wildMagic == 25)
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 94);
-						for (int k = 0; k < 4; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-5f, 5f), Main.rand.NextFloat(-5f, 5f), ModContent.ProjectileType<HighTechClickerPro>(), damage, 0f, player.whoAmI);
-						}
-						for (int k = 0; k < 20; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 229, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
-							dust.noGravity = true;
-						}
-					}
-
-					// Mice Clicker Effect
-					if (itemClickerEffect.Contains("Collision"))
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 105);
-						for (int k = 0; k < 8; k++)
-						{
-							Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-2f, 2f), Main.rand.NextFloat(-2f, 2f), ModContent.ProjectileType<MiceClickerPro>(), (int)(damage * 0.5f), knockBack, player.whoAmI);
-						}
-						for (int k = 0; k < 10; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, ModContent.DustType<MiceDust>(), Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
-							dust.noGravity = true;
-						}
-					}
-
-					// Astral Clicker Effect
-					if (itemClickerEffect.Contains("Spiral"))
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 117);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<AstralClickerPro>(), (int)(damage * 3f), 0f, player.whoAmI);
-						for (int k = 0; k < 20; k++)
-						{
-							Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, ModContent.DustType<MiceDust>(), Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
-							dust.noGravity = true;
-						}
-					}
-
-					// Moon Lord Clicker Effect
-					if (itemClickerEffect.Contains("Conqueror"))
-					{
-						Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 88);
-						Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<LordsClickerPro>(), (int)(damage * 2f), 0f, player.whoAmI);
-					}
-
-					wildMagic = 0;
-				}
 				return false;
 			}
 			return base.Shoot(item, player, ref position, ref speedX, ref speedY, ref type, ref damage, ref knockBack);

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -409,7 +409,7 @@ namespace ClickerClass.Items
 					clickerPlayer.Click();
 				}
 
-				//TODO "PreShoot" hook wrapping around the next NewProjectile
+				//TODO dire: maybe "PreShoot" hook wrapping around the next NewProjectile
 
 				//Spawn normal click damage
 				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, type, damage, knockBack, player.whoAmI);

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -261,7 +261,7 @@ namespace ClickerClass.Items
 								}
 							}
 
-							if (key != null)
+							if (!showDesc)
 							{
 								tooltips.Insert(++index, new TooltipLine(mod, "ForMoreInfo", $"Hold 'Auto Select' key ({key}) to show click effects")
 								{

--- a/Items/ClickerItemCore.cs
+++ b/Items/ClickerItemCore.cs
@@ -232,12 +232,13 @@ namespace ClickerClass.Items
 					List<string> effects = new List<string>(itemClickEffects);
 					foreach (var name in ClickerSystem.GetAllEffectNames())
 					{
-						var heldItemEffects = player.HeldItem.GetGlobalItem<ClickerItemCore>().itemClickEffects;
-						if (clickerPlayer.HasClickEffect(name, out ClickEffect effect) &&
-							!effects.Contains(name) &&
-							player.HeldItem.type == item.type && !heldItemEffects.Contains(name))
+						if (clickerPlayer.HasClickEffect(name, out ClickEffect effect) && !effects.Contains(name))
 						{
-							effects.Add(name);
+							var heldItemEffects = player.HeldItem.GetGlobalItem<ClickerItemCore>().itemClickEffects;
+							if (!(player.HeldItem.type != item.type && heldItemEffects.Contains(name)))
+							{
+								effects.Add(name);
+							}
 						}
 					}
 

--- a/Items/ClickerWeapon.cs
+++ b/Items/ClickerWeapon.cs
@@ -1,4 +1,6 @@
 using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
 using Terraria;
 using Terraria.ModLoader;
 
@@ -25,6 +27,7 @@ namespace ClickerClass.Items
 			ClickerSystem.SetClickerWeaponDefaults(item);
 		}
 
+		//TODO update desc
 		/// <summary>
 		/// Call in <see cref="ModItem.SetDefaults"/> for a clicker weapon to set its color used for various things
 		/// </summary>
@@ -51,29 +54,49 @@ namespace ClickerClass.Items
 			}
 		}
 
-		/// <summary>
-		/// Call in <see cref="ModItem.SetDefaults"/> for a clicker weapon to set the amount of clicks required for an effect to trigger
-		/// </summary>
-		/// <param name="item">The clicker weapon</param>
-		/// <param name="amount">the amount of clicks</param>
+		[Obsolete("Use AddEffect instead", true)]
 		public static void SetAmount(Item item, int amount)
 		{
-			if (ClickerSystem.IsClickerWeapon(item, out ClickerItemCore clickerItem))
-			{
-				clickerItem.itemClickerAmount = amount;
-			}
+			//Nothing
+		}
+
+		[Obsolete("Use AddEffect instead", true)]
+		public static void SetEffect(Item item, string effect)
+		{
+			AddEffect(item, effect);
 		}
 
 		/// <summary>
-		/// Call in <see cref="ModItem.SetDefaults"/> for a clicker weapon to define its effect
+		/// Call in <see cref="ModItem.SetDefaults"/> for a clicker weapon to add an effect to it
 		/// </summary>
 		/// <param name="item">The clicker weapon</param>
 		/// <param name="effect">the effect name</param>
-		public static void SetEffect(Item item, string effect)
+		public static void AddEffect(Item item, string effect)
+		{
+			AddEffect(item, new List<string> { effect });
+		}
+
+		/// <summary>
+		/// Call in <see cref="ModItem.SetDefaults"/> for a clicker weapon to add effects to it
+		/// </summary>
+		/// <param name="item">The clicker weapon</param>
+		/// <param name="effects">the effect names</param>
+		public static void AddEffect(Item item, IEnumerable<string> effects)
 		{
 			if (ClickerSystem.IsClickerWeapon(item, out ClickerItemCore clickerItem))
 			{
-				clickerItem.itemClickerEffect = effect ?? ClickerItemCore.NULL;
+				//Check against already added effects
+				List<string> list = clickerItem.itemClickEffects;
+				foreach (var name in effects)
+				{
+					if (!string.IsNullOrEmpty(name) && !list.Contains(name))
+					{
+						if (ClickerSystem.IsClickEffect(name, out _))
+						{
+							list.Add(name);
+						}
+					}
+				}
 			}
 		}
 

--- a/Items/ClickerWeapon.cs
+++ b/Items/ClickerWeapon.cs
@@ -27,9 +27,8 @@ namespace ClickerClass.Items
 			ClickerSystem.SetClickerWeaponDefaults(item);
 		}
 
-		//TODO update desc
 		/// <summary>
-		/// Call in <see cref="ModItem.SetDefaults"/> for a clicker weapon to set its color used for various things
+		/// Call in <see cref="ModItem.SetDefaults"/> for a clicker weapon to set its radius color
 		/// </summary>
 		/// <param name="item">The clicker weapon</param>
 		/// <param name="color">The color</param>

--- a/Items/ClickerWeapon.cs
+++ b/Items/ClickerWeapon.cs
@@ -37,7 +37,7 @@ namespace ClickerClass.Items
 		{
 			if (ClickerSystem.IsClickerWeapon(item, out ClickerItemCore clickerItem))
 			{
-				clickerItem.clickerColorItem = color;
+				clickerItem.clickerRadiusColor = color;
 			}
 		}
 

--- a/Items/Weapons/Clickers/AdamantiteClicker.cs
+++ b/Items/Weapons/Clickers/AdamantiteClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Adamantite Clicker");
+
+			ClickEffect.TrueStrike = ClickerSystem.RegisterClickEffect(mod, "TrueStrike", "True Strike", "Deals double damage and always inflicts a critical hit", 10, new Color(255, 25, 25, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 71);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<AdamantiteClickerPro>(), damage, knockBack, player.whoAmI);
+			});
 		}
 
 		public override void SetDefaults()
@@ -19,8 +27,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3.15f);
 			SetColor(item, new Color(255, 25, 25, 0));
 			SetDust(item, 50);
-			SetAmount(item, 10);
-			SetEffect(item, "True Strike");
+			AddEffect(item, ClickEffect.TrueStrike);
 
 			item.damage = 32;
 			item.width = 30;

--- a/Items/Weapons/Clickers/ArthursClicker.cs
+++ b/Items/Weapons/Clickers/ArthursClicker.cs
@@ -1,4 +1,7 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using System;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +13,48 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Arthur's Clicker");
+
+			ClickEffect.HolyNova = ClickerSystem.RegisterClickEffect(mod, "HolyNova", "Holy Nova", "Damages every enemy within the clicker's radius with a guaranteed critical hit", 12, new Color(255, 225, 0, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.NPCHit, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 5);
+				for (int u = 0; u < Main.maxNPCs; u++)
+				{
+					NPC target = Main.npc[u];
+					if (Collision.CanHit(target.Center, 1, 1, Main.MouseWorld, 1, 1) && target.DistanceSQ(Main.MouseWorld) < 350 * 350)
+					{
+						Vector2 vector = target.Center - Main.MouseWorld;
+						float speed = 8f;
+						float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
+						if (mag > speed)
+						{
+							mag = speed / mag;
+						}
+						vector *= mag;
+						Projectile.NewProjectile(target.Center.X, target.Center.Y, 0f, 0f, ModContent.ProjectileType<ArthursClickerPro>(), (int)(damage * 0.75f), knockBack, player.whoAmI, 1f, 0f);
+
+						for (int k = 0; k < 30; k++)
+						{
+							Dust dust = Dust.NewDustDirect(target.Center, 8, 8, 87, vector.X + Main.rand.NextFloat(-1f, 1f), vector.Y + Main.rand.NextFloat(-1f, 1f), 0, default, 1.25f);
+							dust.noGravity = true;
+						}
+					}
+				}
+
+				float num102 = 100f;
+				int num103 = 0;
+				while ((float)num103 < num102)
+				{
+					Vector2 vector12 = Vector2.UnitX * 0f;
+					vector12 += -Vector2.UnitY.RotatedBy((double)((float)num103 * (6.28318548f / num102)), default(Vector2)) * new Vector2(2f, 2f);
+					vector12 = vector12.RotatedBy((double)Vector2.Zero.ToRotation(), default(Vector2));
+					int num104 = Dust.NewDust(Main.MouseWorld, 0, 0, 87, 0f, 0f, 0, default(Color), 2f);
+					Main.dust[num104].noGravity = true;
+					Main.dust[num104].position = Main.MouseWorld + vector12;
+					Main.dust[num104].velocity = Vector2.Zero * 0f + vector12.SafeNormalize(Vector2.UnitY) * 15f;
+					int num = num103;
+					num103 = num + 1;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +63,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3.5f);
 			SetColor(item, new Color(255, 225, 0, 0));
 			SetDust(item, 87);
-			SetAmount(item, 12);
-			SetEffect(item, "Holy Nova");
-
+			AddEffect(item, ClickEffect.HolyNova);
 
 			item.damage = 50;
 			item.width = 30;

--- a/Items/Weapons/Clickers/AstralClicker.cs
+++ b/Items/Weapons/Clickers/AstralClicker.cs
@@ -1,4 +1,5 @@
 using ClickerClass.Dusts;
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
@@ -12,6 +13,17 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Astral Clicker");
+
+			ClickEffect.Spiral = ClickerSystem.RegisterClickEffect(mod, "Spiral", "Spiral", "Creates a spiral galaxy that draws in enemies within close proximity", 15, new Color(150, 150, 225, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 117);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<AstralClickerPro>(), (int)(damage * 3f), 0f, player.whoAmI);
+				for (int k = 0; k < 20; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, ModContent.DustType<MiceDust>(), Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
+					dust.noGravity = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -20,9 +32,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 6f);
 			SetColor(item, new Color(150, 150, 225, 0));
 			SetDust(item, ModContent.DustType<MiceDust>());
-			SetAmount(item, 15);
-			SetEffect(item, "Spiral");
-
+			AddEffect(item, ClickEffect.Spiral);
 
 			item.damage = 82;
 			item.knockBack = 1f;

--- a/Items/Weapons/Clickers/BoneClicker.cs
+++ b/Items/Weapons/Clickers/BoneClicker.cs
@@ -1,7 +1,8 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-
 namespace ClickerClass.Items.Weapons.Clickers
 {
 	public class BoneClicker : ClickerWeapon
@@ -10,6 +11,17 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Bone Clicker");
+
+			ClickEffect.Lacerate = ClickerSystem.RegisterClickEffect(mod, "Lacerate", "Lacerate", "Inflicts the Gouge debuff, dealing 30 damage per second", 12, new Color(225, 225, 200, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 71);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<BoneClickerPro>(), damage, knockBack, player.whoAmI);
+				for (int k = 0; k < 10; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 5, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 125, default, 1.25f);
+					dust.noGravity = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +30,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.1f);
 			SetColor(item, new Color(225, 225, 200, 0));
 			SetDust(item, 216);
-			SetAmount(item, 12);
-			SetEffect(item, "Lacerate");
-
+			AddEffect(item, ClickEffect.Lacerate);
 
 			item.damage = 13;
 			item.width = 30;

--- a/Items/Weapons/Clickers/CandleClicker.cs
+++ b/Items/Weapons/Clickers/CandleClicker.cs
@@ -1,4 +1,8 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -8,6 +12,20 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Candle Clicker");
+
+			ClickEffect.Illuminate = ClickerSystem.RegisterClickEffect(mod, "Illuminate", "Illuminate", "Creates 8 sparks along nearby tiles that illuminates the area", 10, new Color(255, 175, 75, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 74);
+				for (int k = 0; k < 15; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 55, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 255, default, 1.35f);
+					dust.noGravity = true;
+				}
+				for (int k = 0; k < 8; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-5f, 5f), Main.rand.NextFloat(-5f, 5f), ModContent.ProjectileType<CandleClickerPro>(), 0, 0f, player.whoAmI);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -16,9 +34,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.5f);
 			SetColor(item, new Color(255, 175, 75, 0));
 			SetDust(item, 55);
-			SetAmount(item, 10);
-			SetEffect(item, "Illuminate");
-
+			AddEffect(item, ClickEffect.Illuminate);
 
 			item.damage = 8;
 			item.width = 30;

--- a/Items/Weapons/Clickers/CaptainsClicker.cs
+++ b/Items/Weapons/Clickers/CaptainsClicker.cs
@@ -1,4 +1,9 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using System;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -8,6 +13,26 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Captain's Clicker");
+
+			ClickEffect.Bombard = ClickerSystem.RegisterClickEffect(mod, "Bombard", "Bombard", "Causes 4 cannonballs to rain from the sky", 12, new Color(255, 225, 50, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 14);
+
+				for (int k = 0; k < 4; k++)
+				{
+					Vector2 startSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-150, 151), Main.MouseWorld.Y - 500 + Main.rand.Next(-25, 26));
+					Vector2 endSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-25, 26), Main.MouseWorld.Y + Main.rand.Next(-25, 26));
+					Vector2 vector = endSpot - startSpot;
+					float speed = 8f + Main.rand.NextFloat(-1f, 1f);
+					float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
+					if (mag > speed)
+					{
+						mag = speed / mag;
+					}
+					vector *= mag;
+					Projectile.NewProjectile(startSpot.X, startSpot.Y, vector.X, vector.Y, ModContent.ProjectileType<CaptainsClickerPro>(), damage, knockBack, player.whoAmI, endSpot.X, endSpot.Y);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -16,9 +41,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3.15f);
 			SetColor(item, new Color(255, 225, 50, 0));
 			SetDust(item, 10);
-			SetAmount(item, 12);
-			SetEffect(item, "Bombard");
-
+			AddEffect(item, ClickEffect.Bombard);
 
 			item.damage = 30;
 			item.width = 30;

--- a/Items/Weapons/Clickers/ChlorophyteClicker.cs
+++ b/Items/Weapons/Clickers/ChlorophyteClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,15 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Chlorophyte Clicker");
+
+			ClickEffect.ToxicRelease = ClickerSystem.RegisterClickEffect(mod, "ToxicRelease", "Toxic Release", "Expels 10 poisonous clouds around the cursor that linger", 10, new Color(175, 255, 100, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 104);
+				for (int k = 0; k < 10; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-5f, 5f), Main.rand.NextFloat(-5f, 5f), ModContent.ProjectileType<ChlorophyteClickerPro>(), (int)(damage * 0.5f), 0f, player.whoAmI);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +29,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3.75f);
 			SetColor(item, new Color(175, 255, 100, 0));
 			SetDust(item, 89);
-			SetAmount(item, 10);
-			SetEffect(item, "Toxic Release");
-
+			AddEffect(item, ClickEffect.ToxicRelease);
 
 			item.damage = 54;
 			item.width = 30;

--- a/Items/Weapons/Clickers/CobaltClicker.cs
+++ b/Items/Weapons/Clickers/CobaltClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Buffs;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,26 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Cobalt Clicker");
+
+			ClickEffect.Haste = ClickerSystem.RegisterClickEffect(mod, "Haste", "Haste", "Grants a jump boost and increased movement speed", 5, new Color(50, 125, 200, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
+				player.AddBuff(ModContent.BuffType<Haste>(), 300, false);
+				for (int i = 0; i < 15; i++)
+				{
+					int num6 = Dust.NewDust(player.position, 20, 20, 56, 0f, 0f, 150, default(Color), 1.25f);
+					Main.dust[num6].noGravity = true;
+					Main.dust[num6].velocity *= 0.75f;
+					int num7 = Main.rand.Next(-50, 51);
+					int num8 = Main.rand.Next(-50, 51);
+					Dust dust = Main.dust[num6];
+					dust.position.X += num7;
+					Dust dust2 = Main.dust[num6];
+					dust2.position.Y += num8;
+					Main.dust[num6].velocity.X = -num7 * 0.075f;
+					Main.dust[num6].velocity.Y = -num8 * 0.075f;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +40,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.75f);
 			SetColor(item, new Color(50, 125, 200, 0));
 			SetDust(item, 48);
-			SetAmount(item, 5);
-			SetEffect(item, "Haste");
-
+			AddEffect(item, ClickEffect.Haste);
 
 			item.damage = 24;
 			item.width = 30;

--- a/Items/Weapons/Clickers/CopperClicker.cs
+++ b/Items/Weapons/Clickers/CopperClicker.cs
@@ -18,9 +18,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.1f);
 			SetColor(item, new Color(255, 150, 75, 0));
 			SetDust(item, 9);
-			SetAmount(item, 10);
-			SetEffect(item, "Double Click");
-
+			AddEffect(item, ClickEffect.DoubleClick);
 
 			item.damage = 4;
 			item.width = 30;

--- a/Items/Weapons/Clickers/CorruptClicker.cs
+++ b/Items/Weapons/Clickers/CorruptClicker.cs
@@ -1,3 +1,4 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
@@ -11,6 +12,17 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Corrupt Clicker");
+
+			ClickEffect.CursedEruption = ClickerSystem.RegisterClickEffect(mod, "CursedEruption", "Cursed Eruption", "Deals damage in a large area of effect and inflicts Oiled and Cursed Inferno", 8, new Color(125, 255, 0, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 74);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<CorruptClickerPro>(), damage, knockBack, player.whoAmI);
+				for (int k = 0; k < 30; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 163, Main.rand.NextFloat(-10f, 10f), Main.rand.NextFloat(-10f, 10f), 0, default, 1.65f);
+					dust.noGravity = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -19,9 +31,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3.25f);
 			SetColor(item, new Color(125, 255, 0, 0));
 			SetDust(item, 163);
-			SetAmount(item, 8);
-			SetEffect(item, "Cursed Eruption");
-
+			AddEffect(item, ClickEffect.CursedEruption);
 
 			item.damage = 31;
 			item.width = 30;

--- a/Items/Weapons/Clickers/CrimsonClicker.cs
+++ b/Items/Weapons/Clickers/CrimsonClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,15 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Crimson Clicker");
+
+			ClickEffect.Infest = ClickerSystem.RegisterClickEffect(mod, "Infest", "Infest", "Fires 8 ichor streams that home in at enemies", 10, new Color(255, 225, 175, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
+				for (int k = 0; k < 8; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-3f, 3f), Main.rand.NextFloat(-3f, 3f), ModContent.ProjectileType<CrimsonClickerPro>(), (int)(damage * 0.25f), knockBack, player.whoAmI);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +29,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.9f);
 			SetColor(item, new Color(255, 225, 175, 0));
 			SetDust(item, 87);
-			SetAmount(item, 10);
-			SetEffect(item, "Infest");
-
+			AddEffect(item, ClickEffect.Infest);
 
 			item.damage = 30;
 			item.width = 30;

--- a/Items/Weapons/Clickers/CrystalClicker.cs
+++ b/Items/Weapons/Clickers/CrystalClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Crystal Clicker");
+
+			ClickEffect.Dazzle = ClickerSystem.RegisterClickEffect(mod, "Dazzle", "Dazzle", "Inflicts the Confused debuff", 8, new Color(200, 50, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 28);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<CrystalClickerPro>(), 0, knockBack, player.whoAmI);
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +26,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3.1f);
 			SetColor(item, new Color(200, 50, 255, 0));
 			SetDust(item, 86);
-			SetAmount(item, 8);
-			SetEffect(item, "Dazzle");
-
+			AddEffect(item, ClickEffect.Dazzle);
 
 			item.damage = 34;
 			item.width = 30;

--- a/Items/Weapons/Clickers/DarkClicker.cs
+++ b/Items/Weapons/Clickers/DarkClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,17 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Dark Clicker");
+
+			ClickEffect.DarkBurst = ClickerSystem.RegisterClickEffect(mod, "DarkBurst", "Dark Burst", "Deals damage in a large area of effect", 8, new Color(100, 50, 200, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 70);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<DarkClickerPro>(), damage, knockBack, player.whoAmI);
+				for (int k = 0; k < 25; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 14, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 75, default, 1.5f);
+					dust.noGravity = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +31,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.1f);
 			SetColor(item, new Color(100, 50, 200, 0));
 			SetDust(item, 14);
-			SetAmount(item, 8);
-			SetEffect(item, "Dark Burst");
-
+			AddEffect(item, ClickEffect.DarkBurst);
 
 			item.damage = 10;
 			item.width = 30;

--- a/Items/Weapons/Clickers/EclipticClicker.cs
+++ b/Items/Weapons/Clickers/EclipticClicker.cs
@@ -1,4 +1,8 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -8,6 +12,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Ecliptic Clicker");
+
+			ClickEffect.Totality = ClickerSystem.RegisterClickEffect(mod, "Totality", "Totality", "Creates a miniature eclipse, repeatedly firing out homing projectiles", 15, new Color(255, 200, 100, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 43);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<TotalityClickerPro>(), damage, knockBack, player.whoAmI);
+			});
 		}
 
 		public override void SetDefaults()
@@ -16,9 +26,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3.5f);
 			SetColor(item, new Color(255, 200, 100, 0));
 			SetDust(item, 264);
-			SetAmount(item, 15);
-			SetEffect(item, "Totality");
-
+			AddEffect(item, ClickEffect.Totality);
 
 			item.damage = 48;
 			item.width = 30;

--- a/Items/Weapons/Clickers/FrozenClicker.cs
+++ b/Items/Weapons/Clickers/FrozenClicker.cs
@@ -10,6 +10,9 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Frozen Clicker");
+
+			//TODO lie because FrozenClickerPro
+			ClickEffect.Freeze = ClickerSystem.RegisterClickEffect(mod, "Freeze", "Freeze", "Inflicts the Frozen debuff", 1, new Color(175, 255, 255, 0), null);
 		}
 
 		public override void SetDefaults()
@@ -18,9 +21,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 6f);
 			SetColor(item, new Color(175, 255, 255, 0));
 			SetDust(item, 15);
-			SetAmount(item, 1);
-			SetEffect(item, "Freeze");
-
+			AddEffect(item, ClickEffect.Freeze);
 
 			item.damage = 82;
 			item.width = 30;

--- a/Items/Weapons/Clickers/GoldClicker.cs
+++ b/Items/Weapons/Clickers/GoldClicker.cs
@@ -18,9 +18,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.6f);
 			SetColor(item, new Color(255, 200, 25, 0));
 			SetDust(item, 10);
-			SetAmount(item, 8);
-			SetEffect(item, "Double Click");
-
+			AddEffect(item, ClickEffect.DoubleClick2);
 
 			item.damage = 8;
 			item.width = 30;

--- a/Items/Weapons/Clickers/HemoClicker.cs
+++ b/Items/Weapons/Clickers/HemoClicker.cs
@@ -1,4 +1,8 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -8,6 +12,15 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Hemo Clicker");
+
+			ClickEffect.Linger = ClickerSystem.RegisterClickEffect(mod, "Linger", "Linger", "Creates 5 gravity-affected blood globules that linger", 10, new Color(255, 50, 50, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.NPCHit, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 13);
+				for (int k = 0; k < 5; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-3f, -1f), ModContent.ProjectileType<HemoClickerPro>(), damage / 2, 0f, player.whoAmI);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -16,9 +29,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.75f);
 			SetColor(item, new Color(255, 50, 50, 0));
 			SetDust(item, 5);
-			SetAmount(item, 10);
-			SetEffect(item, "Linger");
-
+			AddEffect(item, ClickEffect.Linger);
 
 			item.damage = 6;
 			item.width = 30;

--- a/Items/Weapons/Clickers/HighTechClicker.cs
+++ b/Items/Weapons/Clickers/HighTechClicker.cs
@@ -1,4 +1,7 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -8,6 +11,20 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("High Tech Clicker");
+
+			ClickEffect.Discharge = ClickerSystem.RegisterClickEffect(mod, "Discharge", "Discharge", "Blasts out 4 short-ranged lasers around the cursor", 10, new Color(75, 255, 200, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 94);
+				for (int k = 0; k < 4; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-5f, 5f), Main.rand.NextFloat(-5f, 5f), ModContent.ProjectileType<HighTechClickerPro>(), damage, 0f, player.whoAmI);
+				}
+				for (int k = 0; k < 20; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 229, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
+					dust.noGravity = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -16,9 +33,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 6f);
 			SetColor(item, new Color(75, 255, 200, 0));
 			SetDust(item, 226);
-			SetAmount(item, 10);
-			SetEffect(item, "Discharge");
-
+			AddEffect(item, ClickEffect.Discharge);
 
 			item.damage = 90;
 			item.width = 30;

--- a/Items/Weapons/Clickers/HoneyGlazedClicker.cs
+++ b/Items/Weapons/Clickers/HoneyGlazedClicker.cs
@@ -13,7 +13,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Honey Glazed Clicker");
 
-			//TODO
+			//TODO HoneyGlazedClickerPro here
 			ClickEffect.StickyHoney = ClickerSystem.RegisterClickEffect(mod, "StickyHoney", "Sticky Honey", "Inflicts the Honey debuff, significantly slowing down enemies", 1, new Color(255, 175, 0, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
 			{
 

--- a/Items/Weapons/Clickers/HoneyGlazedClicker.cs
+++ b/Items/Weapons/Clickers/HoneyGlazedClicker.cs
@@ -1,5 +1,6 @@
 using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -11,6 +12,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Honey Glazed Clicker");
+
+			//TODO
+			ClickEffect.StickyHoney = ClickerSystem.RegisterClickEffect(mod, "StickyHoney", "Sticky Honey", "Inflicts the Honey debuff, significantly slowing down enemies", 1, new Color(255, 175, 0, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+
+			});
 		}
 
 		public override void SetDefaults()
@@ -19,9 +26,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.45f);
 			SetColor(item, new Color(255, 175, 0, 0));
 			SetDust(item, 153);
-			SetAmount(item, 1);
-			SetEffect(item, "Sticky Honey");
-
+			AddEffect(item, ClickEffect.StickyHoney);
 
 			item.damage = 13;
 			item.width = 30;

--- a/Items/Weapons/Clickers/IronClicker.cs
+++ b/Items/Weapons/Clickers/IronClicker.cs
@@ -18,9 +18,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.25f);
 			SetColor(item, new Color(150, 125, 125, 0));
 			SetDust(item, 8);
-			SetAmount(item, 10);
-			SetEffect(item, "Double Click");
-
+			AddEffect(item, ClickEffect.DoubleClick);
 
 			item.damage = 5;
 			item.width = 30;

--- a/Items/Weapons/Clickers/LeadClicker.cs
+++ b/Items/Weapons/Clickers/LeadClicker.cs
@@ -18,9 +18,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.3f);
 			SetColor(item, new Color(75, 75, 125, 0));
 			SetDust(item, 82);
-			SetAmount(item, 10);
-			SetEffect(item, "Double Click");
-
+			AddEffect(item, ClickEffect.DoubleClick);
 
 			item.damage = 5;
 			item.width = 30;

--- a/Items/Weapons/Clickers/LihzahrdClicker.cs
+++ b/Items/Weapons/Clickers/LihzahrdClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Lihzahrd Clicker");
+
+			ClickEffect.SolarFlare = ClickerSystem.RegisterClickEffect(mod, "SolarFlare", "Solar Flare", "Spawns a lingering sun projectile that damages and inflicts the Oiled and On Fire! debuffs", 10, new Color(200, 75, 0, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 68);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<LihzarhdClickerPro>(), (int)(damage * 0.5f), 0f, player.whoAmI);
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +26,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 4f);
 			SetColor(item, new Color(200, 75, 0, 0));
 			SetDust(item, 174);
-			SetAmount(item, 10);
-			SetEffect(item, "Solar Flare");
-
+			AddEffect(item, ClickEffect.SolarFlare);
 
 			item.damage = 66;
 			item.width = 30;

--- a/Items/Weapons/Clickers/LordsClicker.cs
+++ b/Items/Weapons/Clickers/LordsClicker.cs
@@ -1,5 +1,8 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -9,6 +12,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Lord's Clicker");
+
+			ClickEffect.Conqueror = ClickerSystem.RegisterClickEffect(mod, "Conqueror", "Conqueror", "Creates an area-of-effect phantasmal explosion that deals double damage and a guaranteed critical hit", 15, new Color(100, 255, 200, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 88);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<LordsClickerPro>(), (int)(damage * 2f), 0f, player.whoAmI);
+			});
 		}
 
 		public override void SetDefaults()
@@ -17,9 +26,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 6f);
 			SetColor(item, new Color(100, 255, 200, 0));
 			SetDust(item, 110);
-			SetAmount(item, 15);
-			SetEffect(item, "Conqueror");
-
+			AddEffect(item, ClickEffect.Conqueror);
 
 			item.damage = 122;
 			item.width = 30;

--- a/Items/Weapons/Clickers/MiceClicker.cs
+++ b/Items/Weapons/Clickers/MiceClicker.cs
@@ -1,4 +1,5 @@
 using ClickerClass.Dusts;
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
@@ -12,6 +13,20 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Mice Clicker");
+
+			ClickEffect.Collision = ClickerSystem.RegisterClickEffect(mod, "Collision", "Collision", "Fires out 8 erratic bolts outwards that, after a second, collapse back", 10, new Color(150, 150, 225, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 105);
+				for (int k = 0; k < 8; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-2f, 2f), Main.rand.NextFloat(-2f, 2f), ModContent.ProjectileType<MiceClickerPro>(), (int)(damage * 0.5f), knockBack, player.whoAmI);
+				}
+				for (int k = 0; k < 10; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, ModContent.DustType<MiceDust>(), Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 0, default, 1.25f);
+					dust.noGravity = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -20,9 +35,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 6f);
 			SetColor(item, new Color(150, 150, 225, 0));
 			SetDust(item, ModContent.DustType<MiceDust>());
-			SetAmount(item, 10);
-			SetEffect(item, "Collision");
-
+			AddEffect(item, ClickEffect.Collision);
 
 			item.damage = 94;
 			item.width = 30;

--- a/Items/Weapons/Clickers/MythrilClicker.cs
+++ b/Items/Weapons/Clickers/MythrilClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Mythril Clicker");
+
+			ClickEffect.Embrittle = ClickerSystem.RegisterClickEffect(mod, "Embrittle", "Embrittle", "Inflicts the Embrittle debuff, increasing the amount of damage enemies take from clickers by a flat 8", 10, new Color(125, 225, 125, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 101);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<MythrilClickerPro>(), 0, knockBack, player.whoAmI);
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +26,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.95f);
 			SetColor(item, new Color(125, 225, 125, 0));
 			SetDust(item, 49);
-			SetAmount(item, 10);
-			SetEffect(item, "Embrittle");
-
+			AddEffect(item, ClickEffect.Embrittle);
 
 			item.damage = 25;
 			item.width = 30;

--- a/Items/Weapons/Clickers/OrichalcumClicker.cs
+++ b/Items/Weapons/Clickers/OrichalcumClicker.cs
@@ -1,4 +1,7 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using System;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +13,30 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Orichalcum Clicker");
+
+			ClickEffect.PetalStorm = ClickerSystem.RegisterClickEffect(mod, "PetalStorm", "Petal Storm", "Causes 5 petal projectiles to be summoned near the player and shoot across the screen", 10, new Color(255, 150, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
+
+				for (int k = 0; k < 5; k++)
+				{
+					float xChoice = Main.rand.Next(-100, 101);
+					float yChoice = Main.rand.Next(-100, 101);
+					xChoice += xChoice > 0 ? 300 : -300;
+					yChoice += yChoice > 0 ? 300 : -300;
+					Vector2 startSpot = new Vector2(Main.MouseWorld.X + xChoice, Main.MouseWorld.Y + yChoice);
+					Vector2 endSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-10, 11), Main.MouseWorld.Y + Main.rand.Next(-10, 11));
+					Vector2 vector = endSpot - startSpot;
+					float speed = 4f;
+					float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
+					if (mag > speed)
+					{
+						mag = speed / mag;
+					}
+					vector *= mag;
+					Projectile.NewProjectile(startSpot.X, startSpot.Y, vector.X, vector.Y, ModContent.ProjectileType<OrichaclumClickerPro>(), (int)(damage * 0.5f), 0f, player.whoAmI, Main.rand.Next(3), 0f);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +45,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3f);
 			SetColor(item, new Color(255, 150, 255, 0));
 			SetDust(item, 145);
-			SetAmount(item, 10);
-			SetEffect(item, "Petal Storm");
-
+			AddEffect(item, ClickEffect.PetalStorm);
 
 			item.damage = 28;
 			item.width = 30;

--- a/Items/Weapons/Clickers/PalladiumClicker.cs
+++ b/Items/Weapons/Clickers/PalladiumClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Dusts;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,26 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Palladium Clicker");
+
+			ClickEffect.Regenerate = ClickerSystem.RegisterClickEffect(mod, "Regenerate", "Regenerate", "Grants the Rapid Healing buff, increasing the player's life regeneration", 8, new Color(250, 150, 100, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
+				player.AddBuff(BuffID.RapidHealing, 120, false);
+				for (int i = 0; i < 15; i++)
+				{
+					int num6 = Dust.NewDust(player.position, 20, 20, ModContent.DustType<LoveDust>(), 0f, 0f, 0, Color.White, 1f);
+					Main.dust[num6].noGravity = true;
+					Main.dust[num6].velocity *= 0.75f;
+					int num7 = Main.rand.Next(-50, 51);
+					int num8 = Main.rand.Next(-50, 51);
+					Dust dust = Main.dust[num6];
+					dust.position.X = dust.position.X + (float)num7;
+					Dust dust2 = Main.dust[num6];
+					dust2.position.Y = dust2.position.Y + (float)num8;
+					Main.dust[num6].velocity.X = -(float)num7 * 0.075f;
+					Main.dust[num6].velocity.Y = -(float)num8 * 0.075f;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +40,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.85f);
 			SetColor(item, new Color(250, 150, 100, 0));
 			SetDust(item, 144);
-			SetAmount(item, 8);
-			SetEffect(item, "Regenerate");
-
+			AddEffect(item, ClickEffect.Regenerate);
 
 			item.damage = 25;
 			item.width = 30;

--- a/Items/Weapons/Clickers/PlatinumClicker.cs
+++ b/Items/Weapons/Clickers/PlatinumClicker.cs
@@ -1,7 +1,6 @@
 using Microsoft.Xna.Framework;
 using Terraria.ID;
 using Terraria.ModLoader;
-
 namespace ClickerClass.Items.Weapons.Clickers
 {
 	public class PlatinumClicker : ClickerWeapon
@@ -18,9 +17,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.65f);
 			SetColor(item, new Color(125, 150, 175, 0));
 			SetDust(item, 11);
-			SetAmount(item, 8);
-			SetEffect(item, "Double Click");
-
+			AddEffect(item, ClickEffect.DoubleClick2);
 
 			item.damage = 8;
 			item.width = 30;

--- a/Items/Weapons/Clickers/PointyClicker.cs
+++ b/Items/Weapons/Clickers/PointyClicker.cs
@@ -1,4 +1,7 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using System;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +13,35 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Pointy Clicker");
+
+			ClickEffect.StingingThorn = ClickerSystem.RegisterClickEffect(mod, "StingingThorn", "Stinging Thorn", "Fires a thorn projectile that travels towards the nearest enemy", 8, new Color(100, 175, 75, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 17);
+
+				Vector2 pos = Main.MouseWorld;
+
+				int index = -1;
+				for (int i = 0; i < 200; i++)
+				{
+					NPC npc = Main.npc[i];
+					if (npc.active && npc.CanBeChasedBy() && Vector2.DistanceSquared(pos, npc.Center) < 400f * 400f && Collision.CanHit(pos, 1, 1, npc.Center, 1, 1))
+					{
+						index = i;
+					}
+				}
+				if (index != -1)
+				{
+					Vector2 vector = Main.npc[index].Center - pos;
+					float speed = 3f;
+					float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
+					if (mag > speed)
+					{
+						mag = speed / mag;
+					}
+					vector *= mag;
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, vector.X, vector.Y, ModContent.ProjectileType<PointyClickerPro>(), damage, knockBack, player.whoAmI);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +50,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.35f);
 			SetColor(item, new Color(100, 175, 75, 0));
 			SetDust(item, 39);
-			SetAmount(item, 8);
-			SetEffect(item, "Stinging Thorn");
-
+			AddEffect(item, ClickEffect.StingingThorn);
 
 			item.damage = 12;
 			item.width = 30;

--- a/Items/Weapons/Clickers/RedHotClicker.cs
+++ b/Items/Weapons/Clickers/RedHotClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Red Hot Clicker");
+
+			ClickEffect.Inferno = ClickerSystem.RegisterClickEffect(mod, "Inferno", "Inferno", "Creates an explosion, dealing damage and inflicting the Oiled and On Fire! debuffs", 8, new Color(255, 125, 0, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 74);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<RedHotClickerPro>(), 0, knockBack, player.whoAmI);
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +26,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.6f);
 			SetColor(item, new Color(255, 125, 0, 0));
 			SetDust(item, 174);
-			SetAmount(item, 8);
-			SetEffect(item, "Inferno");
-
+			AddEffect(item, ClickEffect.Inferno);
 
 			item.damage = 17;
 			item.width = 30;

--- a/Items/Weapons/Clickers/ShadowyClicker.cs
+++ b/Items/Weapons/Clickers/ShadowyClicker.cs
@@ -1,5 +1,8 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
-
+using System;
+using Terraria;
+using Terraria.ModLoader;
 namespace ClickerClass.Items.Weapons.Clickers
 {
 	public class ShadowyClicker : ClickerWeapon
@@ -8,6 +11,40 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Shadowy Clicker");
+
+			ClickEffect.Curse = ClickerSystem.RegisterClickEffect(mod, "Curse", "Curse", "Fires a shadowflame skull towards the nearest enemy", 12, new Color(150, 100, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 104);
+				for (int k = 0; k < 15; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 27, Main.rand.NextFloat(-6f, 6f), Main.rand.NextFloat(-6f, 6f), 255, default, 1f);
+					dust.noGravity = true;
+				}
+
+				Vector2 pos = Main.MouseWorld;
+
+				int index = -1;
+				for (int i = 0; i < 200; i++)
+				{
+					NPC npc = Main.npc[i];
+					if (npc.active && npc.CanBeChasedBy() && Vector2.DistanceSquared(pos, npc.Center) < 400f * 400f && Collision.CanHit(pos, 1, 1, npc.Center, 1, 1))
+					{
+						index = i;
+					}
+				}
+				if (index != -1)
+				{
+					Vector2 vector = Main.npc[index].Center - pos;
+					float speed = 6f;
+					float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
+					if (mag > speed)
+					{
+						mag = speed / mag;
+					}
+					vector *= mag;
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, vector.X, vector.Y, ModContent.ProjectileType<ShadowyClickerPro>(), damage, knockBack, player.whoAmI);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -16,9 +53,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.15f);
 			SetColor(item, new Color(150, 100, 255, 0));
 			SetDust(item, 27);
-			SetAmount(item, 12);
-			SetEffect(item, "Curse");
-
+			AddEffect(item, ClickEffect.Curse);
 
 			item.damage = 12;
 			item.width = 30;

--- a/Items/Weapons/Clickers/ShroomiteClicker.cs
+++ b/Items/Weapons/Clickers/ShroomiteClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Buffs;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,27 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Shroomite Clicker");
+
+			ClickEffect.AutoClick = ClickerSystem.RegisterClickEffect(mod, "AutoClick", "Auto Click", "Grants the Auto Click buff, reducing the use time, but granting auto-use", 20, new Color(150, 150, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				player.GetModPlayer<ClickerPlayer>().clickAmount++;
+				Main.PlaySound(2, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 24);
+				player.AddBuff(ModContent.BuffType<AutoClick>(), 300, false);
+				for (int i = 0; i < 15; i++)
+				{
+					int num6 = Dust.NewDust(player.position, 20, 20, 15, 0f, 0f, 255, default(Color), 1.5f);
+					Main.dust[num6].noGravity = true;
+					Main.dust[num6].velocity *= 0.75f;
+					int num7 = Main.rand.Next(-50, 51);
+					int num8 = Main.rand.Next(-50, 51);
+					Dust dust = Main.dust[num6];
+					dust.position.X += num7;
+					Dust dust2 = Main.dust[num6];
+					dust2.position.Y += num8;
+					Main.dust[num6].velocity.X = -num7 * 0.075f;
+					Main.dust[num6].velocity.Y = -num8 * 0.075f;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +41,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 6f);
 			SetColor(item, new Color(150, 150, 255, 0));
 			SetDust(item, 113);
-			SetAmount(item, 20);
-			SetEffect(item, "Auto Click");
-
+			AddEffect(item, ClickEffect.AutoClick);
 
 			item.damage = 68;
 			item.width = 30;

--- a/Items/Weapons/Clickers/SilverClicker.cs
+++ b/Items/Weapons/Clickers/SilverClicker.cs
@@ -18,8 +18,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.4f);
 			SetColor(item, new Color(200, 225, 225, 0));
 			SetDust(item, 11);
-			SetAmount(item, 8);
-			SetEffect(item, "Double Click");
+			AddEffect(item, ClickEffect.DoubleClick2);
 
 
 			item.damage = 6;

--- a/Items/Weapons/Clickers/SinisterClicker.cs
+++ b/Items/Weapons/Clickers/SinisterClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,26 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Sinister Clicker");
+
+			ClickEffect.Siphon = ClickerSystem.RegisterClickEffect(mod, "Siphon", "Siphon", "Deals a small amount of damage and restores the player's health by 5", 10, new Color(100, 25, 25, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 112);
+				Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<SinisterClickerPro>(), (int)(damage * 0.50f), knockBack, player.whoAmI);
+				for (int i = 0; i < 15; i++)
+				{
+					int num6 = Dust.NewDust(Main.MouseWorld, 20, 20, 5, 0f, 0f, 75, default(Color), 1.5f);
+					Main.dust[num6].noGravity = true;
+					Main.dust[num6].velocity *= 0.75f;
+					int num7 = Main.rand.Next(-50, 51);
+					int num8 = Main.rand.Next(-50, 51);
+					Dust dust = Main.dust[num6];
+					dust.position.X += num7;
+					Dust dust2 = Main.dust[num6];
+					dust2.position.Y += num8;
+					Main.dust[num6].velocity.X = -num7 * 0.075f;
+					Main.dust[num6].velocity.Y = -num8 * 0.075f;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +40,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.2f);
 			SetColor(item, new Color(100, 25, 25, 0));
 			SetDust(item, 5);
-			SetAmount(item, 10);
-			SetEffect(item, "Siphon");
-
+			AddEffect(item, ClickEffect.Siphon);
 
 			item.damage = 10;
 			item.width = 30;

--- a/Items/Weapons/Clickers/SlickClicker.cs
+++ b/Items/Weapons/Clickers/SlickClicker.cs
@@ -1,4 +1,8 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -8,6 +12,15 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Slick Clicker");
+
+			ClickEffect.Splash = ClickerSystem.RegisterClickEffect(mod, "Splash", "Splash", "Creates a fountain of 6 damaging water projectiles", 6, new Color(75, 75, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 86);
+				for (int k = 0; k < 6; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-1f, 1f), Main.rand.NextFloat(-6f, -2f), ModContent.ProjectileType<SlickClickerPro>(), (int)(damage * 0.75f), knockBack, player.whoAmI);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -16,9 +29,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.45f);
 			SetColor(item, new Color(75, 75, 255, 0));
 			SetDust(item, 33);
-			SetAmount(item, 6);
-			SetEffect(item, "Splash");
-
+			AddEffect(item, ClickEffect.Splash);
 
 			item.damage = 11;
 			item.width = 30;

--- a/Items/Weapons/Clickers/SpaceClicker.cs
+++ b/Items/Weapons/Clickers/SpaceClicker.cs
@@ -1,4 +1,7 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using System;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +13,26 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Space Clicker");
+
+			ClickEffect.StarStorm = ClickerSystem.RegisterClickEffect(mod, "StarStorm", "Star Storm", "Causes 3 stars to fall from the sky and explode", 6, new Color(175, 75, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 42);
+
+				for (int k = 0; k < 3; k++)
+				{
+					Vector2 startSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-100, 101), Main.MouseWorld.Y - 500 + Main.rand.Next(-25, 26));
+					Vector2 endSpot = new Vector2(Main.MouseWorld.X + Main.rand.Next(-25, 26), Main.MouseWorld.Y + Main.rand.Next(-25, 26));
+					Vector2 vector = endSpot - startSpot;
+					float speed = 5f;
+					float mag = (float)Math.Sqrt(vector.X * vector.X + vector.Y * vector.Y);
+					if (mag > speed)
+					{
+						mag = speed / mag;
+					}
+					vector *= mag;
+					Projectile.NewProjectile(startSpot.X, startSpot.Y, vector.X, vector.Y, ModContent.ProjectileType<SpaceClickerPro>(), (int)(damage * 0.75f), knockBack, player.whoAmI, endSpot.X, endSpot.Y);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +41,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.25f);
 			SetColor(item, new Color(175, 125, 125, 0));
 			SetDust(item, 174);
-			SetAmount(item, 8);
-			SetEffect(item, "Star Storm");
-
+			AddEffect(item, ClickEffect.StarStorm);
 
 			item.damage = 10;
 			item.width = 30;

--- a/Items/Weapons/Clickers/SpectreClicker.cs
+++ b/Items/Weapons/Clickers/SpectreClicker.cs
@@ -11,6 +11,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Spectre Clicker");
 			Tooltip.SetDefault("Click on an enemy within sight to damage them");
+
+			ClickEffect.PhaseReach = ClickerSystem.RegisterClickEffect(mod, "PhaseReach", "Phase Reach", "Damage enemies regardless of location", 1, new Color(100, 255, 255, 0), null);
 		}
 
 		public override void SetDefaults()
@@ -19,9 +21,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 5f);
 			SetColor(item, new Color(100, 255, 255, 0));
 			SetDust(item, 88);
-			SetAmount(item, 1);
-			SetEffect(item, "Phase Reach");
-
+			AddEffect(item, ClickEffect.PhaseReach);
 
 			item.damage = 50;
 			item.width = 30;

--- a/Items/Weapons/Clickers/TheClicker.cs
+++ b/Items/Weapons/Clickers/TheClicker.cs
@@ -9,6 +9,12 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("The Clicker");
+
+			//TODO orphaned?
+			ClickEffect.TheClick = ClickerSystem.RegisterClickEffect(mod, "TheClick", "The Click", "Causes the clicker's attacks to additionally deal damage equal to 1% of the enemy's maximum life", 1, new Color(255, 255, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+
+			});
 		}
 
 		public override void SetDefaults()
@@ -17,9 +23,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 6f);
 			SetColor(item, new Color(255, 255, 255, 0));
 			SetDust(item, 91);
-			SetAmount(item, 1);
-			SetEffect(item, "The Click");
-
+			AddEffect(item, ClickEffect.TheClick);
 
 			item.damage = 150;
 			item.width = 30;

--- a/Items/Weapons/Clickers/TinClicker.cs
+++ b/Items/Weapons/Clickers/TinClicker.cs
@@ -18,9 +18,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.15f);
 			SetColor(item, new Color(125, 125, 75, 0));
 			SetDust(item, 81);
-			SetAmount(item, 10);
-			SetEffect(item, "Double Click");
-
+			AddEffect(item, ClickEffect.DoubleClick);
 
 			item.damage = 4;
 			item.width = 30;

--- a/Items/Weapons/Clickers/TitaniumClicker.cs
+++ b/Items/Weapons/Clickers/TitaniumClicker.cs
@@ -1,4 +1,6 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -10,6 +12,20 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Titanium Clicker");
+
+			ClickEffect.RazorsEdge = ClickerSystem.RegisterClickEffect(mod, "RazorsEdge", "Razor's Edge", "Fires out 5 orbiting sawblades that spread outwards", 12, new Color(150, 150, 150, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 22);
+				for (int k = 0; k < 5; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, 0f, 0f, ModContent.ProjectileType<TitaniumClickerPro>(), (int)(damage * 0.75f), 0f, player.whoAmI, k, 0f);
+				}
+				for (int k = 0; k < 15; k++)
+				{
+					Dust dust = Dust.NewDustDirect(Main.MouseWorld, 8, 8, 91, Main.rand.NextFloat(-3f, 3f), Main.rand.NextFloat(-3f, 3f), 0, default, 1.25f);
+					dust.noGravity = true;
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +34,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 3.25f);
 			SetColor(item, new Color(150, 150, 150, 0));
 			SetDust(item, 146);
-			SetAmount(item, 12);
-			SetEffect(item, "Razor's Edge");
-
+			AddEffect(item, ClickEffect.RazorsEdge);
 
 			item.damage = 44;
 			item.width = 30;

--- a/Items/Weapons/Clickers/TungstenClicker.cs
+++ b/Items/Weapons/Clickers/TungstenClicker.cs
@@ -18,9 +18,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 1.45f);
 			SetColor(item, new Color(125, 175, 150, 0));
 			SetDust(item, 83);
-			SetAmount(item, 8);
-			SetEffect(item, "Double Click");
-
+			AddEffect(item, ClickEffect.DoubleClick2);
 
 			item.damage = 6;
 			item.width = 30;

--- a/Items/Weapons/Clickers/UmbralClicker.cs
+++ b/Items/Weapons/Clickers/UmbralClicker.cs
@@ -1,7 +1,8 @@
+using ClickerClass.Projectiles;
 using Microsoft.Xna.Framework;
+using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
-
 namespace ClickerClass.Items.Weapons.Clickers
 {
 	public class UmbralClicker : ClickerWeapon
@@ -10,6 +11,15 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Umbral Clicker");
+
+			ClickEffect.ShadowLash = ClickerSystem.RegisterClickEffect(mod, "ShadowLash", "Shadow Lash", "Causes a burst of 5 shadow projectiles to seek out nearby enemies", 10, new Color(150, 100, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				Main.PlaySound(SoundID.Item, (int)Main.MouseWorld.X, (int)Main.MouseWorld.Y, 103);
+				for (int k = 0; k < 5; k++)
+				{
+					Projectile.NewProjectile(Main.MouseWorld.X, Main.MouseWorld.Y, Main.rand.NextFloat(-3f, 3f), Main.rand.NextFloat(-3f, 3f), ModContent.ProjectileType<UmbralClickerPro>(), (int)(damage * 0.5f), knockBack, player.whoAmI);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -18,9 +28,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 2.75f);
 			SetColor(item, new Color(150, 100, 255, 0));
 			SetDust(item, 27);
-			SetAmount(item, 10);
-			SetEffect(item, "Shadow Lash");
-
+			AddEffect(item, ClickEffect.ShadowLash);
 
 			item.damage = 20;
 			item.width = 30;

--- a/Items/Weapons/Clickers/WitchClicker.cs
+++ b/Items/Weapons/Clickers/WitchClicker.cs
@@ -1,4 +1,6 @@
 using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using Terraria;
 
 namespace ClickerClass.Items.Weapons.Clickers
 {
@@ -8,6 +10,33 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			base.SetStaticDefaults();
 			DisplayName.SetDefault("Witch Clicker");
+
+			ClickEffect.WildMagic = ClickerSystem.RegisterClickEffect(mod, "WildMagic", "Wild Magic", "Randomly acts as any possible click effect", 6, new Color(175, 75, 255, 0), delegate (Player player, Vector2 position, int type, int damage, float knockBack)
+			{
+				List<string> excluded = new List<string>
+				{
+					ClickEffect.WildMagic,
+					ClickEffect.Conqueror
+				};
+
+				List<string> allowed = new List<string>();
+
+				foreach (var name in ClickerSystem.GetAllEffectNames())
+				{
+					if (!excluded.Contains(name))
+					{
+						allowed.Add(name);
+					}
+				}
+
+				if (allowed.Count == 0) return;
+
+				string random = Main.rand.Next(allowed);
+				if (ClickerSystem.IsClickEffect(random, out ClickEffect effect))
+				{
+					effect.Action?.Invoke(player, position, type, damage, knockBack);
+				}
+			});
 		}
 
 		public override void SetDefaults()
@@ -16,9 +45,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 			SetRadius(item, 6f);
 			SetColor(item, new Color(175, 75, 255, 0));
 			SetDust(item, 173);
-			SetAmount(item, 6);
-			SetEffect(item, "Wild Magic");
-
+			AddEffect(item, ClickEffect.WildMagic);
 
 			item.damage = 78;
 			item.width = 30;

--- a/Projectiles/TheClickerPro.cs
+++ b/Projectiles/TheClickerPro.cs
@@ -3,6 +3,7 @@ using Terraria.Graphics.Shaders;
 
 namespace ClickerClass.Projectiles
 {
+	//TODO orphaned?
 	public class TheClickerPro : ClickerProjectile
 	{
 		public override void SetDefaults()

--- a/UI/ClickerCursor.cs
+++ b/UI/ClickerCursor.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 using Terraria;
+using Terraria.ModLoader;
 using Terraria.UI;
 
 namespace ClickerClass.UI
@@ -42,11 +43,22 @@ namespace ClickerClass.UI
 				return true;
 			}
 
-			Texture2D borderTexture = ClickerClass.mod.GetTexture("UI/CursorOutline");
-			Texture2D texture;
 			Item item = player.HeldItem;
+
+			Texture2D borderTexture;
+			Texture2D texture;
 			if (CanDrawCursor(item))
 			{
+				string borderTexturePath = ClickerSystem.GetPathToBorderTexture(item.type);
+				if (borderTexturePath != null)
+				{
+					borderTexture = ModContent.GetTexture(borderTexturePath);
+				}
+				else
+				{
+					//Default border
+					borderTexture = ClickerClass.mod.GetTexture("UI/CursorOutline");
+				}
 				texture = Main.itemTexture[item.type];
 			}
 			else

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
 author = DivermanSam, Barometz, and direwolf420
-version = 1.2.1
+version = 1.2.2
 displayName = The Clicker Class
 homepage = https://discord.com/invite/ZyYdrZg
 includePDB = true


### PR DESCRIPTION
This PR entirely changes how click effects work, cleans up tooltips (in code and ingame), fixes a few bugs, marks a few bugs that have to be fixed later, and adds all the new effect features + some more stuff to the API. Incremented build version to `1.2.2`.

## Click Effects
A Click Effect is now represented by an object called `ClickEffect` that contains common info about it, such as name, amount, color, and most importantly, its action (so it does things). This cleans up the gigantic chain of effects in the `Shoot` hook by simply looping over each effect.
The benefit of this is that it is more dynamic, accessories can apply those effects aswell, and you can add more than one effect to a clicker weapon. Sticky Keychain and Chocolate Chip are converted to this new system (and thus, buffed through click amount reducing effects), and this API is exposed to other modders, so they can add and work with these effects.

## Tooltips
New "hold shift to show more info" feature on clicker weapons that de-bloats the list of enabled effects a bit by hiding/showing descriptions. Some code improvements regarding them aswell.

## Bugfixes
Glass Of Milk has been fixed to properly scale now (instead of giving a 15% damage increase directly after the first click), and utilizes a much more accurate `clickerPerSecond` variable (that is also available via API). 

## API and ExampleMod
* Fixes
    * Fixed `GetPlayerStat->clickAmountTotal` call not working at all, now also requires an effect name as a parameter

* Removals/Changes
     * *Reminder that all of these are still backwards compatible, you don't HAVE to update your mod immediately*
     * `SetAmount` is deleted
     * `SetEffect` is obsolete
     * `GetAccessory/SetAccessory`->`ChocolateChip/StickyKeychain` is obsolete

* Additions/Changes
     * Added `borderTexture` parameter for `RegisterClickerWeapon`
     * Added `GetPathToBorderTexture`
     * Added `RegisterClickEffect`, `IsClickEffect`, `AddEffect`, `GetAllEffectNames`, `GetClickEffectAsDict`, `EnableClickEffect` and `HasClickEffect`
     * Added `GetPlayerStat`->`clickerPerSecond`

* ClickerClassExampleMod
    * Updated **ClickerCompat**
    * Changed the code to adapt to the new API
    * Added an advanced clicker weapon, adding a custom effect which uses a custom clicker projectile



## 'Yet to be fixed' Bugs and misc
* The Click/The Clicker 1% damage based on lifeMax is missing entirely from the code
* Reimplement Honey Glazed Clicker and Frozen Clicker the same way the Red Hot Clicker works
* Clickers now support custom border textures/outlines, which can be applied to the different shapes this mod's clickers have (i.e Silver Clicker being a bit smaller than other clickers)
