### PR TITLE
Add Mod of Redemption Elemental damage mod support

### DIFF
--- a/ClickerClass.cs
+++ b/ClickerClass.cs
@@ -184,7 +184,7 @@ namespace ClickerClass
 
 		public static void RegisterElement(this Item item, int elementID, bool projsInheritItemElements = false)
 		{
-			if (!Main.dedServ && ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
+			if (ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
 			{
 				redemptionMod.Call("addElementItem", elementID, item.type, projsInheritItemElements);
 			}
@@ -192,7 +192,7 @@ namespace ClickerClass
 
 		public static void RegisterElement(this Projectile projectile, int elementID)
 		{
-			if (!Main.dedServ && ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
+			if (ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
 			{
 				redemptionMod.Call("addElementProj", elementID, projectile.type);
 			}

--- a/ClickerClass.cs
+++ b/ClickerClass.cs
@@ -163,4 +163,39 @@ namespace ClickerClass
 			}
 		}
 	}
+
+	public static class MoRSupportHelper
+	{
+		public const short Arcane = 1;
+		public const short Fire = 2;
+		public const short Water = 3;
+		public const short Ice = 4;
+		public const short Earth = 5;
+		public const short Wind = 6;
+		public const short Thunder = 7;
+		public const short Holy = 8;
+		public const short Shadow = 9;
+		public const short Nature = 10;
+		public const short Poison = 11;
+		public const short Blood = 12;
+		public const short Psychic = 13;
+		public const short Celestial = 14;
+		public const short Explosive = 15;
+
+		public static void RegisterElement(this Item item, int elementID, bool projsInheritItemElements = false)
+		{
+			if (!Main.dedServ && ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
+			{
+				redemptionMod.Call("addElementItem", elementID, item.type, projsInheritItemElements);
+			}
+		}
+
+		public static void RegisterElement(this Projectile projectile, int elementID)
+		{
+			if (!Main.dedServ && ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
+			{
+				redemptionMod.Call("addElementProj", elementID, projectile.type);
+			}
+		}
+	}
 }

--- a/ClickerClass.cs
+++ b/ClickerClass.cs
@@ -164,6 +164,10 @@ namespace ClickerClass
 		}
 	}
 
+	/// <summary>
+	/// Handles mod call support for Mod of Redemption.
+	/// See <a href="https://modofredemption.wiki.gg/wiki/Mod_Calls">MoR wiki</a> for further information.
+	/// </summary>
 	public static class MoRSupportHelper
 	{
 		public const short Arcane = 1;
@@ -182,6 +186,12 @@ namespace ClickerClass
 		public const short Celestial = 14;
 		public const short Explosive = 15;
 
+		/// <summary>
+		/// Registers an item under a given <a href="https://modofredemption.wiki.gg/wiki/Elemental_damage">MoR element</a>, applying damage multipliers based on the element and enemy type, and other unique effects based on the element.
+		/// </summary>
+		/// <param name="item">The Item to apply the element to.</param>
+		/// <param name="elementID">The ID of the element to apply to the item. Use <see cref="MoRSupportHelper">MoRSupportHelper</see> consts (ex. <see cref="MoRSupportHelper.Fire">MoRSupportHelper.Fire</see>).</param>
+		/// <param name="projsInheritItemElements">Whether the element should also be applied to any projectiles spawned by the item. Defaults to false.</param>
 		public static void RegisterElement(this Item item, int elementID, bool projsInheritItemElements = false)
 		{
 			if (ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
@@ -190,11 +200,33 @@ namespace ClickerClass
 			}
 		}
 
+		/// <summary>
+		/// Registers a projectile under a given <a href="https://modofredemption.wiki.gg/wiki/Elemental_damage">MoR element</a>, applying damage multipliers based on the element and enemy type, and other unique effects based on the element.
+		/// </summary>
+		/// <param name="projectile">The Projectile to apply the element to.</param>
+		/// <param name="elementID">The ID of the element to apply to the item. Use <see cref="MoRSupportHelper">MoRSupportHelper</see> consts (ex. <see cref="MoRSupportHelper.Fire">MoRSupportHelper.Fire</see>).</param>
+		/// <param name="projsInheritProjElements">Whether the element should also be applied to any projectiles spawned by the projectile. Defaults to false.</param>
 		public static void RegisterElement(this Projectile projectile, int elementID, bool projsInheritProjElements = false)
 		{
 			if (ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
 			{
 				redemptionMod.Call("addElementProj", elementID, projectile.type, projsInheritProjElements);
+			}
+		}
+
+		/// <summary>
+		/// Checks if a given attack will trigger MoR's <a href="https://modofredemption.wiki.gg/wiki/Elemental_damage#Decapitation">decapitation</a> mechanic, instantly killing certain enemies and dropping their heads if applicable.
+		/// To be called on an onHitNPC() function.
+		/// </summary>
+		/// <param name="target">The NPC to try the decapitation on. This is normally the target parameter from an onHitNPC() function.</param>
+		/// <param name="damageDone">The damage dealt by the attack to try the decapitation on. This is normally the damageDone parameter from an onHitNPC() function.</param>
+		/// <param name="isCrit">Whether the attack to try the decapitation on was a critical hit. This is normally the hit.Crit parameter from an onHitNPC() function.</param>
+		/// <param name="chance">The chance the attack successfully decapitates or not. Defaults to 200 (1/200 chance).</param>
+		public static void tryDecapitation(NPC target, int damageDone, bool isCrit, int chance = 200)
+		{
+			if (ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
+			{
+				redemptionMod.Call("decapitation", target, damageDone, isCrit, chance);
 			}
 		}
 	}

--- a/ClickerClass.cs
+++ b/ClickerClass.cs
@@ -190,11 +190,11 @@ namespace ClickerClass
 			}
 		}
 
-		public static void RegisterElement(this Projectile projectile, int elementID)
+		public static void RegisterElement(this Projectile projectile, int elementID, bool projsInheritProjElements = false)
 		{
 			if (ModLoader.TryGetMod("Redemption", out Mod redemptionMod))
 			{
-				redemptionMod.Call("addElementProj", elementID, projectile.type);
+				redemptionMod.Call("addElementProj", elementID, projectile.type, projsInheritProjElements);
 			}
 		}
 	}

--- a/Items/Accessories/BigRedButton.cs
+++ b/Items/Accessories/BigRedButton.cs
@@ -18,6 +18,8 @@ namespace ClickerClass.Items.Accessories
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire); // For tooltip
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Explosive); // For tooltip
 
 			ClickEffect.BigRedButton = ClickerSystem.RegisterClickEffect(Mod, "BigRedButton", ClickAmount, new Color(230, 100, 20, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Accessories/ClearKeychain.cs
+++ b/Items/Accessories/ClearKeychain.cs
@@ -13,6 +13,7 @@ namespace ClickerClass.Items.Accessories
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Holy); // For tooltip
 
 			ClickEffect.ClearKeychain = ClickerSystem.RegisterClickEffect(Mod, "ClearKeychain", 15, new Color(225, 200, 255, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Accessories/HotKeychain.cs
+++ b/Items/Accessories/HotKeychain.cs
@@ -10,6 +10,7 @@ namespace ClickerClass.Items.Accessories
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire); // For tooltip
 		}
 
 		public override void SetDefaults()

--- a/Items/Accessories/MasterKeychain.cs
+++ b/Items/Accessories/MasterKeychain.cs
@@ -6,6 +6,14 @@ namespace ClickerClass.Items.Accessories
 {
 	public class MasterKeychain : ClickerItem
 	{
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire); // For tooltip
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Water); // For tooltip
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Holy); // For tooltip
+		}
+
 		public override void SetDefaults()
 		{
 			Item.width = 20;

--- a/Items/Accessories/StickyKeychain.cs
+++ b/Items/Accessories/StickyKeychain.cs
@@ -17,6 +17,7 @@ namespace ClickerClass.Items.Accessories
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Water); // For tooltip
 
 			ClickEffect.StickyKeychain = ClickerSystem.RegisterClickEffect(Mod, "StickyKeychain", ClickAmount, new Color(145, 180, 230, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Tools/MiceDrill.cs
+++ b/Items/Tools/MiceDrill.cs
@@ -27,6 +27,9 @@ namespace ClickerClass.Items.Tools
 			{
 				glowmask = new(() => ModContent.Request<Texture2D>(Texture + "_Glow"));
 			}
+
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 		}
 
 		public override void SetDefaults()

--- a/Items/Tools/MiceHamaxe.cs
+++ b/Items/Tools/MiceHamaxe.cs
@@ -32,6 +32,9 @@ namespace ClickerClass.Items.Tools
 					Color = (PlayerDrawSet drawInfo) => new Color(255, 255, 255, 50) * 0.7f
 				});
 			}
+
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial);
 		}
 
 		public override void SetDefaults()

--- a/Items/Tools/MicePickaxe.cs
+++ b/Items/Tools/MicePickaxe.cs
@@ -32,6 +32,9 @@ namespace ClickerClass.Items.Tools
 					Color = (PlayerDrawSet drawInfo) => new Color(255, 255, 255, 50) * 0.7f
 				});
 			}
+
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial);
 		}
 
 		public override void SetDefaults()

--- a/Items/Weapons/Clickers/ArcaneClicker.cs
+++ b/Items/Weapons/Clickers/ArcaneClicker.cs
@@ -13,6 +13,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
 
 			ClickEffect.ArcaneEnchantment = ClickerSystem.RegisterClickEffect(Mod, "ArcaneEnchantment", 10, new Color(255, 180, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/ArthursClicker.cs
+++ b/Items/Weapons/Clickers/ArthursClicker.cs
@@ -13,6 +13,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Holy, projsInheritItemElements: true);
 
 			ClickEffect.HolyNova = ClickerSystem.RegisterClickEffect(Mod, "HolyNova", 12, new Color(255, 225, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/AstralClicker.cs
+++ b/Items/Weapons/Clickers/AstralClicker.cs
@@ -25,6 +25,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 
 			ClickEffect.Spiral = ClickerSystem.RegisterClickEffect(Mod, "Spiral", 15, new Color(150, 150, 225), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/BalloonClicker.cs
+++ b/Items/Weapons/Clickers/BalloonClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Wind, projsInheritItemElements: true);
 
 			ClickEffect.BalloonDefense = ClickerSystem.RegisterClickEffect(Mod, "BalloonDefense", 20, new Color(200, 125, 125), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/BlizzardClicker.cs
+++ b/Items/Weapons/Clickers/BlizzardClicker.cs
@@ -12,6 +12,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Ice, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Wind, projsInheritItemElements: true);
 
 			ClickEffect.Flurry = ClickerSystem.RegisterClickEffect(Mod, "Flurry", 15, new Color(150, 220, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/BoneClicker.cs
+++ b/Items/Weapons/Clickers/BoneClicker.cs
@@ -13,6 +13,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Earth, projsInheritItemElements: true);
 
 			ClickEffect.Lacerate = ClickerSystem.RegisterClickEffect(Mod, "Lacerate", 12, new Color(225, 225, 200), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/BurningSuperDeathClicker.cs
+++ b/Items/Weapons/Clickers/BurningSuperDeathClicker.cs
@@ -11,6 +11,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
 
 			ClickEffect.Mania = ClickerSystem.RegisterClickEffect(Mod, "Mania", 6, new Color(255, 150, 150), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/CandleClicker.cs
+++ b/Items/Weapons/Clickers/CandleClicker.cs
@@ -14,6 +14,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
 
 			ClickEffect.Illuminate = ClickerSystem.RegisterClickEffect(Mod, "Illuminate", 10, new Color(255, 175, 75), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/ChlorophyteClicker.cs
+++ b/Items/Weapons/Clickers/ChlorophyteClicker.cs
@@ -14,6 +14,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Nature, projsInheritItemElements: true);
 
 			ClickEffect.ToxicRelease = ClickerSystem.RegisterClickEffect(Mod, "ToxicRelease", 10, new Color(175, 255, 100), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/CorruptClicker.cs
+++ b/Items/Weapons/Clickers/CorruptClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Shadow, projsInheritItemElements: true);
 
 			ClickEffect.CursedEruption = ClickerSystem.RegisterClickEffect(Mod, "CursedEruption", 8, new Color(125, 255, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/CrimsonClicker.cs
+++ b/Items/Weapons/Clickers/CrimsonClicker.cs
@@ -15,6 +15,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Blood, projsInheritItemElements: true);
 
 			ClickEffect.Infest = ClickerSystem.RegisterClickEffect(Mod, "Infest", 10, new Color(255, 225, 175), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/CrystalClicker.cs
+++ b/Items/Weapons/Clickers/CrystalClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Holy, projsInheritItemElements: true);
 
 			ClickEffect.Dazzle = ClickerSystem.RegisterClickEffect(Mod, "Dazzle", 8, new Color(200, 50, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/CyclopsClicker.cs
+++ b/Items/Weapons/Clickers/CyclopsClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Ice, projsInheritItemElements: true);
 
 			ClickEffect.Insanity = ClickerSystem.RegisterClickEffect(Mod, "Insanity", 8, new Color(75, 75, 75), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/DarkClicker.cs
+++ b/Items/Weapons/Clickers/DarkClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Shadow, projsInheritItemElements: true);
 
 			ClickEffect.DarkBurst = ClickerSystem.RegisterClickEffect(Mod, "DarkBurst", 8, new Color(100, 50, 200), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/DraconicClicker.cs
+++ b/Items/Weapons/Clickers/DraconicClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
 
 			ClickEffect.WyvernsRoar = ClickerSystem.RegisterClickEffect(Mod, "WyvernsRoar", 10, new Color(175, 55, 135), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/DreamClicker.cs
+++ b/Items/Weapons/Clickers/DreamClicker.cs
@@ -14,6 +14,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 
 			ClickEffect.StarSlice = ClickerSystem.RegisterClickEffect(Mod, "StarSlice", 8, new Color(255, 235, 180), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/EclipticClicker.cs
+++ b/Items/Weapons/Clickers/EclipticClicker.cs
@@ -12,6 +12,9 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Shadow, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 
 			ClickEffect.Totality = ClickerSystem.RegisterClickEffect(Mod, "Totality", 15, new Color(255, 200, 100), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/FaultyClicker.cs
+++ b/Items/Weapons/Clickers/FaultyClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Thunder, projsInheritItemElements: true);
 
 			ClickEffect.Fritz = ClickerSystem.RegisterClickEffect(Mod, "Fritz", 3, new Color(100, 100, 100), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/FrozenClicker.cs
+++ b/Items/Weapons/Clickers/FrozenClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Ice, projsInheritItemElements: true);
 
 			ClickEffect.Freeze = ClickerSystem.RegisterClickEffect(Mod, "Freeze", 1, new Color(175, 255, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/HemoClicker.cs
+++ b/Items/Weapons/Clickers/HemoClicker.cs
@@ -14,6 +14,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Blood, projsInheritItemElements: true);
 
 			ClickEffect.Linger = ClickerSystem.RegisterClickEffect(Mod, "Linger", 10, new Color(255, 50, 50), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/HighTechClicker.cs
+++ b/Items/Weapons/Clickers/HighTechClicker.cs
@@ -15,6 +15,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Thunder, projsInheritItemElements: true);
 
 			ClickEffect.Discharge = ClickerSystem.RegisterClickEffect(Mod, "Discharge", 10, new Color(75, 255, 200), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/HoneyGlazedClicker.cs
+++ b/Items/Weapons/Clickers/HoneyGlazedClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Nature, projsInheritItemElements: true);
 
 			ClickEffect.StickyHoney = ClickerSystem.RegisterClickEffect(Mod, "StickyHoney", 1, new Color(255, 175, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/ImpishClicker.cs
+++ b/Items/Weapons/Clickers/ImpishClicker.cs
@@ -17,6 +17,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
 
 			ClickEffect.HotWings = ClickerSystem.RegisterClickEffect(Mod, "HotWings", 15, new Color(240, 35, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/LanternClicker.cs
+++ b/Items/Weapons/Clickers/LanternClicker.cs
@@ -14,6 +14,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
 
 			ClickEffect.Incinerate = ClickerSystem.RegisterClickEffect(Mod, "Incinerate", 15, new Color(255, 155, 65), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/LihzahrdClicker.cs
+++ b/Items/Weapons/Clickers/LihzahrdClicker.cs
@@ -12,6 +12,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Earth, projsInheritItemElements: true);
 
 			ClickEffect.SolarFlare = ClickerSystem.RegisterClickEffect(Mod, "SolarFlare", 10, new Color(200, 75, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/LordsClicker.cs
+++ b/Items/Weapons/Clickers/LordsClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 
 			ClickEffect.Conqueror = ClickerSystem.RegisterClickEffect(Mod, "Conqueror", 15, new Color(100, 255, 200), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/MiceClicker.cs
+++ b/Items/Weapons/Clickers/MiceClicker.cs
@@ -27,6 +27,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 
 			ClickEffect.Collision = ClickerSystem.RegisterClickEffect(Mod, "Collision", 10, new Color(150, 150, 225), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/MyceliumClicker.cs
+++ b/Items/Weapons/Clickers/MyceliumClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Nature, projsInheritItemElements: true);
 
 			ClickEffect.Spores = ClickerSystem.RegisterClickEffect(Mod, "Spores", 10, new Color(115, 150, 220), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/PharaohsClicker.cs
+++ b/Items/Weapons/Clickers/PharaohsClicker.cs
@@ -12,6 +12,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Earth, projsInheritItemElements: true);
 
 			ClickEffect.PharaohsCommand = ClickerSystem.RegisterClickEffect(Mod, "PharaohsCommand", 25, new Color(250, 220, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/PointyClicker.cs
+++ b/Items/Weapons/Clickers/PointyClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Nature, projsInheritItemElements: true);
 
 			ClickEffect.StingingThorn = ClickerSystem.RegisterClickEffect(Mod, "StingingThorn", 8, new Color(100, 175, 75), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/QuintessenceClicker.cs
+++ b/Items/Weapons/Clickers/QuintessenceClicker.cs
@@ -14,6 +14,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
 
 			ClickEffect.Transcend = ClickerSystem.RegisterClickEffect(Mod, "Transcend", 25, new Color(220, 180, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/RainbowClicker.cs
+++ b/Items/Weapons/Clickers/RainbowClicker.cs
@@ -25,6 +25,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 
 			ClickEffect.Rainbolt = ClickerSystem.RegisterClickEffect(Mod, "Rainbolt", 8, () => Color.Lerp(Color.White, Main.DiscoColor, 0.5f), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/RedHotClicker.cs
+++ b/Items/Weapons/Clickers/RedHotClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
 
 			ClickEffect.Inferno = ClickerSystem.RegisterClickEffect(Mod, "Inferno", 8, new Color(255, 125, 0), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/SandstormClicker.cs
+++ b/Items/Weapons/Clickers/SandstormClicker.cs
@@ -12,6 +12,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Earth, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Wind, projsInheritItemElements: true);
 
 			ClickEffect.DustDevil = ClickerSystem.RegisterClickEffect(Mod, "DustDevil", 10, new Color(220, 185, 120), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/SeafoamClicker.cs
+++ b/Items/Weapons/Clickers/SeafoamClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Water, projsInheritItemElements: true);
 
 			ClickEffect.SeaSpray = ClickerSystem.RegisterClickEffect(Mod, "SeaSpray", 15, new Color(160, 230, 200), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/ShadowyClicker.cs
+++ b/Items/Weapons/Clickers/ShadowyClicker.cs
@@ -12,6 +12,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Shadow, projsInheritItemElements: true);
 
 			ClickEffect.Curse = ClickerSystem.RegisterClickEffect(Mod, "Curse", 12, new Color(150, 100, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/SinisterClicker.cs
+++ b/Items/Weapons/Clickers/SinisterClicker.cs
@@ -14,6 +14,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Blood, projsInheritItemElements: true);
 
 			ClickEffect.Siphon = ClickerSystem.RegisterClickEffect(Mod, "Siphon", 10, new Color(100, 25, 25), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/SlickClicker.cs
+++ b/Items/Weapons/Clickers/SlickClicker.cs
@@ -14,6 +14,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Water, projsInheritItemElements: true);
 
 			ClickEffect.Splash = ClickerSystem.RegisterClickEffect(Mod, "Splash", 6, new Color(75, 75, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/SnottyClicker.cs
+++ b/Items/Weapons/Clickers/SnottyClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Poison, projsInheritItemElements: true);
 
 			ClickEffect.OgreGold = ClickerSystem.RegisterClickEffect(Mod, "OgreGold", 1, new Color(180, 215, 150), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/SpaceClicker.cs
+++ b/Items/Weapons/Clickers/SpaceClicker.cs
@@ -15,6 +15,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 
 			ClickEffect.StarStorm = ClickerSystem.RegisterClickEffect(Mod, "StarStorm", 6, new Color(175, 75, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/SpectreClicker.cs
+++ b/Items/Weapons/Clickers/SpectreClicker.cs
@@ -14,6 +14,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		{
 			//Special tooltip set before this normally, but we use lang keys so it's handled automatically
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
 
 			ClickEffect.PhaseReach = ClickerSystem.RegisterClickEffect(Mod, "PhaseReach", 1, new Color(100, 255, 255), null);
 		}

--- a/Items/Weapons/Clickers/SpiralClicker.cs
+++ b/Items/Weapons/Clickers/SpiralClicker.cs
@@ -15,6 +15,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Blood, projsInheritItemElements: true);
 
 			ClickEffect.BloodSucker = ClickerSystem.RegisterClickEffect(Mod, "BloodSucker", 8, new Color(160, 40, 35), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/StarryClicker.cs
+++ b/Items/Weapons/Clickers/StarryClicker.cs
@@ -12,6 +12,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Celestial, projsInheritItemElements: true);
 
 			ClickEffect.Starfall = ClickerSystem.RegisterClickEffect(Mod, "Starfall", 15, new Color(255, 50, 200), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/TorchClicker.cs
+++ b/Items/Weapons/Clickers/TorchClicker.cs
@@ -27,6 +27,9 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Holy, projsInheritItemElements: true);
 
 			ClickEffect.Smite = ClickerSystem.RegisterClickEffect(Mod, "Smite", 10, new Color(255, 245, 225), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/UmbralClicker.cs
+++ b/Items/Weapons/Clickers/UmbralClicker.cs
@@ -15,6 +15,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Shadow, projsInheritItemElements: true);
 
 			ClickEffect.ShadowLash = ClickerSystem.RegisterClickEffect(Mod, "ShadowLash", 12, new Color(150, 100, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/WebClicker.cs
+++ b/Items/Weapons/Clickers/WebClicker.cs
@@ -12,6 +12,7 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Nature, projsInheritItemElements: true);
 
 			ClickEffect.WebSplash = ClickerSystem.RegisterClickEffect(Mod, "WebSplash", 10, new Color(190, 190, 175), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Items/Weapons/Clickers/WitchClicker.cs
+++ b/Items/Weapons/Clickers/WitchClicker.cs
@@ -11,6 +11,8 @@ namespace ClickerClass.Items.Weapons.Clickers
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Arcane, projsInheritItemElements: true);
+			MoRSupportHelper.RegisterElement(Item, MoRSupportHelper.Fire, projsInheritItemElements: true);
 
 			ClickEffect.WildMagic = ClickerSystem.RegisterClickEffect(Mod, "WildMagic", 6, new Color(175, 75, 255), delegate (Player player, EntitySource_ItemUse_WithAmmo source, Vector2 position, int type, int damage, float knockBack)
 			{

--- a/Projectiles/ArthursClickerPro.cs
+++ b/Projectiles/ArthursClickerPro.cs
@@ -11,6 +11,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Holy);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/AstralClickerPro.cs
+++ b/Projectiles/AstralClickerPro.cs
@@ -25,6 +25,14 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[1] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/BalloonClickerPro.cs
+++ b/Projectiles/BalloonClickerPro.cs
@@ -41,6 +41,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 6;
 			Main.projPet[Projectile.type] = true;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Wind);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BigRedButtonPro.cs
+++ b/Projectiles/BigRedButtonPro.cs
@@ -10,6 +10,9 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 7;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BigRedButtonPro2.cs
+++ b/Projectiles/BigRedButtonPro2.cs
@@ -15,8 +15,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 4;
 
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire, projsInheritProjElements: true);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive, projsInheritProjElements: true);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BigRedButtonPro2.cs
+++ b/Projectiles/BigRedButtonPro2.cs
@@ -14,6 +14,9 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 4;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BigRedButtonPro3.cs
+++ b/Projectiles/BigRedButtonPro3.cs
@@ -13,6 +13,9 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 4;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BigRedButtonPro3.cs
+++ b/Projectiles/BigRedButtonPro3.cs
@@ -13,9 +13,6 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 4;
-
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BlizzardClickerPro.cs
+++ b/Projectiles/BlizzardClickerPro.cs
@@ -27,6 +27,9 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 6;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Ice);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Wind);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BlizzardClickerPro.cs
+++ b/Projectiles/BlizzardClickerPro.cs
@@ -28,8 +28,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 6;
 
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Ice);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Wind);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Ice, projsInheritProjElements: true);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Wind, projsInheritProjElements: true);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BlizzardClickerPro2.cs
+++ b/Projectiles/BlizzardClickerPro2.cs
@@ -22,9 +22,6 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
-
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Ice);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Wind);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BlizzardClickerPro2.cs
+++ b/Projectiles/BlizzardClickerPro2.cs
@@ -22,6 +22,9 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Ice);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Wind);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/BoneClickerPro.cs
+++ b/Projectiles/BoneClickerPro.cs
@@ -15,6 +15,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Blood);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/CaptainsClickerPro.cs
+++ b/Projectiles/CaptainsClickerPro.cs
@@ -17,6 +17,9 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/ChlorophyteClickerPro.cs
+++ b/Projectiles/ChlorophyteClickerPro.cs
@@ -12,6 +12,14 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Nature);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Poison);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/ClearKeychainPro.cs
+++ b/Projectiles/ClearKeychainPro.cs
@@ -21,6 +21,8 @@ namespace ClickerClass.Projectiles
 
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Holy);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/ClearKeychainPro.cs
+++ b/Projectiles/ClearKeychainPro.cs
@@ -21,8 +21,6 @@ namespace ClickerClass.Projectiles
 
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
-
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Holy);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/ClearKeychainPro2.cs
+++ b/Projectiles/ClearKeychainPro2.cs
@@ -18,6 +18,8 @@ namespace ClickerClass.Projectiles
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Holy);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/CorruptClickerPro.cs
+++ b/Projectiles/CorruptClickerPro.cs
@@ -13,6 +13,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/CrimsonClickerPro.cs
+++ b/Projectiles/CrimsonClickerPro.cs
@@ -41,6 +41,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.localAI[0] = value;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Water);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/CyclopsClickerPro.cs
+++ b/Projectiles/CyclopsClickerPro.cs
@@ -18,6 +18,9 @@ namespace ClickerClass.Projectiles
 
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 10;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Shadow);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Psychic);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/DarkClickerPro.cs
+++ b/Projectiles/DarkClickerPro.cs
@@ -13,6 +13,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Shadow);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/DraconicClickerPro.cs
+++ b/Projectiles/DraconicClickerPro.cs
@@ -39,6 +39,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 20;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/DraconicClickerPro.cs
+++ b/Projectiles/DraconicClickerPro.cs
@@ -40,7 +40,7 @@ namespace ClickerClass.Projectiles
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 20;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
 
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire, projsInheritProjElements: true);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/DreamClickerPro.cs
+++ b/Projectiles/DreamClickerPro.cs
@@ -32,6 +32,9 @@ namespace ClickerClass.Projectiles
 		{
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Arcane);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/FaultyClickerPro.cs
+++ b/Projectiles/FaultyClickerPro.cs
@@ -13,6 +13,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Thunder);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/HemoClickerPro.cs
+++ b/Projectiles/HemoClickerPro.cs
@@ -19,6 +19,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[1] = value;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Blood);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/HighTechClickerPro.cs
+++ b/Projectiles/HighTechClickerPro.cs
@@ -51,6 +51,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 
 			ProjectileID.Sets.CanDistortWater[Projectile.type] = false;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Thunder);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/HotKeychainPro.cs
+++ b/Projectiles/HotKeychainPro.cs
@@ -13,6 +13,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/LihzarhdClickerPro.cs
+++ b/Projectiles/LihzarhdClickerPro.cs
@@ -17,6 +17,10 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 12;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Earth);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/LordsClickerPro.cs
+++ b/Projectiles/LordsClickerPro.cs
@@ -17,6 +17,9 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 7;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/MiceClickerPro.cs
+++ b/Projectiles/MiceClickerPro.cs
@@ -44,6 +44,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.localAI[0] = value;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/MyceliumClickerPro.cs
+++ b/Projectiles/MyceliumClickerPro.cs
@@ -27,6 +27,8 @@ namespace ClickerClass.Projectiles
 			Main.projFrames[Projectile.type] = 4;
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Nature);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/NaughtyClickerPro.cs
+++ b/Projectiles/NaughtyClickerPro.cs
@@ -31,8 +31,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 2;
 
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire, projsInheritProjElements: true);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive, projsInheritProjElements: true);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/NaughtyClickerPro.cs
+++ b/Projectiles/NaughtyClickerPro.cs
@@ -30,6 +30,9 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 2;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/NaughtyClickerPro2.cs
+++ b/Projectiles/NaughtyClickerPro2.cs
@@ -14,6 +14,14 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[1] = value;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/NaughtyClickerPro2.cs
+++ b/Projectiles/NaughtyClickerPro2.cs
@@ -14,14 +14,6 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[1] = value;
 		}
 
-		public override void SetStaticDefaults()
-		{
-			base.SetStaticDefaults();
-
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Explosive);
-		}
-
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/PharaohsClickerPro.cs
+++ b/Projectiles/PharaohsClickerPro.cs
@@ -38,6 +38,9 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projPet[Projectile.type] = true;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Arcane, projsInheritProjElements: true);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Earth, projsInheritProjElements: true);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/PharaohsClickerPro2.cs
+++ b/Projectiles/PharaohsClickerPro2.cs
@@ -13,14 +13,6 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
-		public override void SetStaticDefaults()
-		{
-			base.SetStaticDefaults();
-
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Arcane);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Earth);
-		}
-
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/PharaohsClickerPro2.cs
+++ b/Projectiles/PharaohsClickerPro2.cs
@@ -16,6 +16,9 @@ namespace ClickerClass.Projectiles
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Arcane);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Earth);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/PointyClickerPro.cs
+++ b/Projectiles/PointyClickerPro.cs
@@ -27,6 +27,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 20;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 2;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Nature);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/PrecursorPro.cs
+++ b/Projectiles/PrecursorPro.cs
@@ -5,6 +5,13 @@ namespace ClickerClass.Projectiles
 {
 	public class PrecursorPro : ClickerProjectile
 	{
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Earth);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/RGBPro.cs
+++ b/Projectiles/RGBPro.cs
@@ -53,6 +53,9 @@ namespace ClickerClass.Projectiles
 			Main.projFrames[Projectile.type] = 2;
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 5;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Arcane);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/RainbowClickerPro.cs
+++ b/Projectiles/RainbowClickerPro.cs
@@ -23,6 +23,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 25;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/SandstormClickerPro.cs
+++ b/Projectiles/SandstormClickerPro.cs
@@ -43,6 +43,9 @@ namespace ClickerClass.Projectiles
 
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 15;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Earth);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Wind);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/ShadowyClickerPro.cs
+++ b/Projectiles/ShadowyClickerPro.cs
@@ -21,6 +21,9 @@ namespace ClickerClass.Projectiles
 			Main.projFrames[Projectile.type] = 4;
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 5;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Shadow);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/SinisterClickerPro.cs
+++ b/Projectiles/SinisterClickerPro.cs
@@ -15,6 +15,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[0] = value ? 1f : 0f;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Blood);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/SlickClickerPro.cs
+++ b/Projectiles/SlickClickerPro.cs
@@ -19,6 +19,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[1] = value;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Water);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/SpaceClickerPro.cs
+++ b/Projectiles/SpaceClickerPro.cs
@@ -31,6 +31,8 @@ namespace ClickerClass.Projectiles
 			Main.projFrames[Projectile.type] = 7;
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/SpiralClickerPro.cs
+++ b/Projectiles/SpiralClickerPro.cs
@@ -37,6 +37,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 20;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Blood);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/StarryClickerPro.cs
+++ b/Projectiles/StarryClickerPro.cs
@@ -42,6 +42,9 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 8;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Arcane);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/StickyKeychainPro.cs
+++ b/Projectiles/StickyKeychainPro.cs
@@ -31,6 +31,8 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 			Main.projFrames[Projectile.type] = 3;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Water);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/TitaniumClickerPro.cs
+++ b/Projectiles/TitaniumClickerPro.cs
@@ -73,6 +73,11 @@ namespace ClickerClass.Projectiles
 			return true;
 		}
 
+		public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
+		{
+			MoRSupportHelper.tryDecapitation(target, damageDone, hit.Crit);
+		}
+
 		public override void AI()
 		{
 			if (HasSpawnEffects)

--- a/Projectiles/TorchClickerPro.cs
+++ b/Projectiles/TorchClickerPro.cs
@@ -21,6 +21,10 @@ namespace ClickerClass.Projectiles
 		public override void SetStaticDefaults()
 		{
 			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Arcane);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Holy);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/TotalityClickerPro.cs
+++ b/Projectiles/TotalityClickerPro.cs
@@ -39,6 +39,15 @@ namespace ClickerClass.Projectiles
 			set => Projectile.ai[1] = value;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Shadow);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/TotalityClickerPro.cs
+++ b/Projectiles/TotalityClickerPro.cs
@@ -43,9 +43,9 @@ namespace ClickerClass.Projectiles
 		{
 			base.SetStaticDefaults();
 
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Shadow);
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Fire, projsInheritProjElements: true);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Shadow, projsInheritProjElements: true);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Celestial, projsInheritProjElements: true);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/UmbralClickerPro.cs
+++ b/Projectiles/UmbralClickerPro.cs
@@ -42,6 +42,13 @@ namespace ClickerClass.Projectiles
 			set => Projectile.localAI[0] = value;
 		}
 
+		public override void SetStaticDefaults()
+		{
+			base.SetStaticDefaults();
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Shadow);
+		}
+
 		public override void SetDefaults()
 		{
 			base.SetDefaults();

--- a/Projectiles/WebClickerPro.cs
+++ b/Projectiles/WebClickerPro.cs
@@ -22,7 +22,7 @@ namespace ClickerClass.Projectiles
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 10;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
 
-			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Nature);
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Nature, projsInheritProjElements: true);
 		}
 
 		public override void SetDefaults()

--- a/Projectiles/WebClickerPro.cs
+++ b/Projectiles/WebClickerPro.cs
@@ -21,6 +21,8 @@ namespace ClickerClass.Projectiles
 			base.SetStaticDefaults();
 			ProjectileID.Sets.TrailCacheLength[Projectile.type] = 10;
 			ProjectileID.Sets.TrailingMode[Projectile.type] = 0;
+
+			MoRSupportHelper.RegisterElement(Projectile, MoRSupportHelper.Nature);
 		}
 
 		public override void SetDefaults()


### PR DESCRIPTION
This PR adds Clicker Class support for [Mod of Redemption's Elemental damage system](https://modofredemption.wiki.gg/wiki/Elemental_damage).

![2025-02-16 13_03_49-Terraria_ Cult of Cenx](https://github.com/user-attachments/assets/c5fbcab0-a27f-4b31-a1fe-cc54cf1c318e)

### Changes
Most weapons, plus some armors and accessories, have been assigned one or more elements that modify damage effectiveness or causes specific interactions. For example, [Slick Clicker](https://terrariamods.wiki.gg/wiki/Clicker_Class/Slick_Clicker) and its clicker effect Splash have been assigned the Water element, causing reduced damage against aquatic enemies, but increased damage against robotic enemies. They also have a chance to inflict the [Electrified debuff](https://modofredemption.wiki.gg/wiki/Electrified_(Mod_of_Redemption)) against them.

For a full list of what elements have been assigned to what weapons/projectiles, [see here](https://docs.google.com/spreadsheets/d/1B0XnI-YKjJ_n0rkCYWgMJurZZbM7NeZqhVxj_nyL3kE/edit).

### Notes
- Clicker effect projectiles do not necessarily require having their elements declared if they are the same as the clicker item due to inheriting from their source, but are included due to Burning Super Death Clicker and Witch Clicker.
